### PR TITLE
Project skeleton with a passing test (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+*.egg-info/
+dist/
+build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "historian"
+version = "0.1.0"
+description = "A SQL query engine over git history"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+historian = "historian.cli:main"
+
+[dependency-groups]
+dev = ["pytest"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/historian"]

--- a/src/historian/__init__.py
+++ b/src/historian/__init__.py
@@ -1,0 +1,3 @@
+"""historian: a SQL query engine over git history."""
+
+__version__ = "0.1.0"

--- a/src/historian/cli.py
+++ b/src/historian/cli.py
@@ -1,0 +1,18 @@
+"""The `historian` command-line entry point.
+
+This is a stub: it takes no arguments and prints a version string.
+The real command line (`-C`, `-f`, `--format`, `--explain`, `--stats`,
+`--no-pushdown`, the REPL) starts at issue #9 and grows through later
+issues in M2/M4/M6.
+"""
+
+from historian import __version__
+
+
+def main() -> int:
+    print(f"historian {__version__}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,14 @@
+"""Tests for historian.cli: the entry point invoked as `uv run historian`."""
+
+import historian
+from historian import cli
+
+
+def test_main_prints_version_and_returns_zero(capsys):
+    """Calling the entry point in-process (not via subprocess) must
+    print the version string to stdout and return exit code 0."""
+    ret = cli.main()
+
+    captured = capsys.readouterr()
+    assert captured.out == f"historian {historian.__version__}\n"
+    assert ret == 0

--- a/tests/test_historian.py
+++ b/tests/test_historian.py
@@ -1,0 +1,16 @@
+"""Tests for the historian package itself: version metadata."""
+
+import tomllib
+from pathlib import Path
+
+import historian
+
+
+def test_version_matches_pyproject():
+    """historian.__version__ must match the version declared in
+    pyproject.toml, not just some hardcoded string that can drift."""
+    pyproject = Path(__file__).parent.parent / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text())
+    expected = data["project"]["version"]
+
+    assert historian.__version__ == expected

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,79 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "historian"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest" }]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]


### PR DESCRIPTION
Closes #1.

Creates the ground everything else stands on: `uv` project, pytest, `src/historian/` package, and a stub entry point.

## What is here

- `pyproject.toml` — Python 3.11+, `pytest` as the only dev dependency, no runtime dependencies, `historian` script entry point
- `uv.lock` — committed, for reproducible installs
- `src/historian/__init__.py`, `src/historian/cli.py` — the package and a no-argument stub that prints the version
- `tests/test_historian.py`, `tests/test_cli.py`
- `.gitignore`

Deliberately absent: `values.py`, `sql/`, `plan/`, `exec/`, `tables/`. Those belong to later issues, and creating them now with placeholder content would make this diff a lie about what it built.

## Verification

QA verdict: PASS on all 12 acceptance criteria — https://github.com/ionut-banu/historian/issues/1#issuecomment-5406005858

`uv run pytest -q` → 2 passed. Checked from a fresh clone: `uv sync` exits 0, `uv run historian` prints `historian 0.1.0` and exits 0, `git status` clean afterwards.

Both tests were confirmed to fail before the code existed, and QA independently re-checked by breaking the version, the exit code, and stdout in turn and confirming each turned the matching test red.

Differential: n/a, no suite until M3. Fuzzer: n/a, not built until M5.

## Known and deferred

`uv run historian foo bar` ignores its arguments rather than erroring. The stub takes no arguments by design; real argument handling is issue 9 (M2).
