### PR TITLE
SQL values, comparison, and three-valued logic (#2)

### DIFF
--- a/src/historian/values.py
+++ b/src/historian/values.py
@@ -1,0 +1,319 @@
+"""SQL values, cross-type comparison, and three-valued logic.
+
+This is the foundation every operator is built on, and per `_docs/spec.md`
+§3 the largest single source of differential mismatches. Every rule here
+is taken from SQLite - checked against the `sqlite3` command-line tool -
+rather than invented. Where historian and SQLite disagree, SQLite is
+right.
+
+Two representations, both using ``None``
+----------------------------------------
+
+``Value`` is ``None | int | float | str``, mirroring SQLite's four
+storage classes NULL / INTEGER / REAL / TEXT. ``Bool3`` is
+``bool | None``: the result of a predicate, meaning SQL ``TRUE`` /
+``FALSE`` / ``NULL``.
+
+``None`` deliberately does double duty - it is both "the value NULL" and
+"the predicate NULL". This is intentional, not an oversight. SQL has one
+NULL and it propagates through both positions identically, so giving it
+two Python spellings would mean a conversion at every boundary between a
+comparison's operands and its result, and every such conversion is a
+place to get NULL handling wrong. Predicates are ``True`` / ``False`` /
+``None`` rather than SQLite's own ``1`` / ``0`` / ``NULL`` integers for
+the same reason: an integer predicate is indistinguishable from an
+integer value.
+
+``bool`` is not a ``Value``
+---------------------------
+
+SQLite has no boolean storage class - ``typeof(true)`` is ``integer`` -
+and no table column in §2 is boolean, so ``bool`` is excluded from
+``Value`` on purpose. But Python's ``bool`` is a subclass of ``int``:
+``isinstance(True, int)`` is ``True`` and ``True == 1`` is ``True``. A
+``Bool3`` that leaked into a ``Value`` position would therefore compare
+as the integer 1 or 0, pass every type check, and produce quietly wrong
+rows.
+
+Every function here validates its arguments and raises ``TypeError`` on a
+``bool`` in a ``Value`` position (and, symmetrically, on an ``int`` in a
+``Bool3`` position). The cost is one isinstance check per call; the
+alternative is a class of bug that never announces itself.
+
+Comparison is not ordering
+--------------------------
+
+``eq`` / ``lt`` / ... implement SQL's three-valued comparison: any
+operand being NULL makes the result NULL. ``ORDER BY`` needs something
+different - a total order with a defined position for NULL - so sorting
+uses :func:`order_key` instead. They are separate functions on purpose.
+
+Contract for the future ``Sort`` operator: ``sorted(rows, key=...)`` on
+:func:`order_key` gives SQLite's ``ASC`` order, and ``DESC`` is that list
+**reversed**, not a negated or complemented key. Confirmed against
+``sqlite3`` that ``ORDER BY x DESC`` is exactly the ascending result
+reversed, NULLs included - so ``Sort`` needs no NULLS-LAST special case
+of its own. (Reversing also reverses the relative order of values that
+compare equal; SQLite does not define that order, and historian's
+own determinism rule is satisfied as long as the reversal is applied to
+an already-deterministic list.)
+
+Grouping is not comparison either
+---------------------------------
+
+``GROUP BY`` and ``DISTINCT`` must key rows by the raw ``Value``, using
+Python's own ``==`` and ``hash()`` - a plain ``dict`` keyed on the value
+is correct. Do **not** key them with :func:`eq`. ``eq(None, None)`` is
+``None``, which is falsy, so using it would put every NULL row in its own
+group; ``None == None`` is ``True``, which is what SQLite does (a column
+of NULL, NULL, 1, 1, 2 gives three groups, and ``SELECT DISTINCT``
+returns one NULL row, not two). Python's ``1 == 1.0`` with
+``hash(1) == hash(1.0)`` likewise matches SQLite grouping an INTEGER 1
+and a REAL 1.0 together. No function is needed for this, which is why
+none is provided.
+
+Not in this module
+------------------
+
+**Column affinity.** ``5 = '5'`` is ``FALSE``, but
+``WHERE line_no = '5'`` is ``TRUE`` against an ``INTEGER`` column,
+because SQLite converts the literal to the column's declared type
+first. Applying that needs to know which operand came from a column and
+how that column was declared - the AST and the schema, neither of which
+this module ever sees. It implements value-to-value comparison only.
+Affinity belongs to ``exec/expression.py``; see ``_docs/spec.md`` §3 and
+the 2026-08-27 entry in ``_docs/decisions.md``.
+
+Also elsewhere: ``LIKE`` / ``IN`` / ``BETWEEN`` / ``CASE``, arithmetic
+and ``||`` (all ``exec/expression.py``), and aggregate accumulation (the
+``Aggregate`` operator).
+"""
+
+__all__ = [
+    "Bool3",
+    "Value",
+    "and3",
+    "eq",
+    "ge",
+    "gt",
+    "is_",
+    "is_not",
+    "is_not_null",
+    "is_null",
+    "is_true",
+    "le",
+    "lt",
+    "ne",
+    "not3",
+    "or3",
+    "order_key",
+]
+
+#: A SQL value: SQLite's NULL, INTEGER, REAL and TEXT storage classes.
+#: ``bool`` and ``bytes`` are deliberately excluded - see the module
+#: docstring.
+Value = None | int | float | str
+
+#: The result of a SQL predicate: ``True``, ``False`` or ``None``,
+#: meaning ``TRUE``, ``FALSE`` and ``NULL``.
+Bool3 = bool | None
+
+# Storage-class ranks, in SQLite's ordering: NULL < numeric < TEXT.
+_RANK_NULL = 0
+_RANK_NUMERIC = 1
+_RANK_TEXT = 2
+
+
+def _rank(value: Value) -> int:
+    """The storage-class rank of *value*, validating its type.
+
+    Raises ``TypeError`` for anything that is not a ``Value`` - including
+    ``bool``, which is checked before ``int`` because it is a subclass of
+    it.
+    """
+    if value is None:
+        return _RANK_NULL
+    if isinstance(value, bool):
+        raise TypeError(
+            "bool is not a SQL Value; a Bool3 predicate result has leaked "
+            f"into a value position (got {value!r})"
+        )
+    if isinstance(value, (int, float)):
+        return _RANK_NUMERIC
+    if isinstance(value, str):
+        return _RANK_TEXT
+    raise TypeError(
+        f"not a SQL Value: {value!r} of type {type(value).__name__}"
+    )
+
+
+def _check_bool3(result: Bool3) -> Bool3:
+    """Validate a ``Bool3``, rejecting SQLite's integer 0/1 spelling."""
+    if result is None or result is True or result is False:
+        return result
+    raise TypeError(
+        f"not a Bool3: {result!r} of type {type(result).__name__}; "
+        "predicates are True, False or None, not 1, 0 or NULL"
+    )
+
+
+def is_true(result: Bool3) -> bool:
+    """Should ``WHERE`` / ``HAVING`` keep this row?
+
+    ``True`` only for ``TRUE``. ``FALSE`` and ``NULL`` are both rejected,
+    and confusing the two is the classic bug (spec §3).
+    """
+    return _check_bool3(result) is True
+
+
+# --- Comparison ----------------------------------------------------------
+#
+# All six return NULL if either operand is NULL. Otherwise values of
+# different storage classes compare by class rank - every number is less
+# than every string, whatever the string looks like ('5' included) - and
+# values of the same class compare directly: numerics by numeric value
+# regardless of int/float subtype, text bytewise.
+
+
+def _compare(left: Value, right: Value) -> int | None:
+    """Three-way compare: -1, 0, 1, or ``None`` when either side is NULL."""
+    left_rank = _rank(left)
+    right_rank = _rank(right)
+    if left_rank == _RANK_NULL or right_rank == _RANK_NULL:
+        return None
+    if left_rank != right_rank:
+        return -1 if left_rank < right_rank else 1
+    if left == right:
+        return 0
+    return -1 if left < right else 1
+
+
+def eq(left: Value, right: Value) -> Bool3:
+    """SQL ``=``."""
+    order = _compare(left, right)
+    return None if order is None else order == 0
+
+
+def ne(left: Value, right: Value) -> Bool3:
+    """SQL ``<>`` / ``!=``."""
+    order = _compare(left, right)
+    return None if order is None else order != 0
+
+
+def lt(left: Value, right: Value) -> Bool3:
+    """SQL ``<``."""
+    order = _compare(left, right)
+    return None if order is None else order < 0
+
+
+def le(left: Value, right: Value) -> Bool3:
+    """SQL ``<=``."""
+    order = _compare(left, right)
+    return None if order is None else order <= 0
+
+
+def gt(left: Value, right: Value) -> Bool3:
+    """SQL ``>``."""
+    order = _compare(left, right)
+    return None if order is None else order > 0
+
+
+def ge(left: Value, right: Value) -> Bool3:
+    """SQL ``>=``."""
+    order = _compare(left, right)
+    return None if order is None else order >= 0
+
+
+# --- IS / IS NOT / IS NULL / IS NOT NULL ---------------------------------
+#
+# These are never NULL. They are storage-class-sensitive, not a loose
+# equality: `1 IS 1.0` is TRUE (both numeric, equal value) while
+# `'1' IS 1` is FALSE (different storage classes).
+
+
+def is_(left: Value, right: Value) -> bool:
+    """SQL ``IS``. Always a plain ``bool``, never ``None``."""
+    left_rank = _rank(left)
+    right_rank = _rank(right)
+    if left_rank != right_rank:
+        return False
+    if left_rank == _RANK_NULL:
+        return True
+    return bool(left == right)
+
+
+def is_not(left: Value, right: Value) -> bool:
+    """SQL ``IS NOT``. Always a plain ``bool``, never ``None``."""
+    return not is_(left, right)
+
+
+def is_null(value: Value) -> bool:
+    """SQL ``IS NULL``. ``0``, ``0.0`` and ``''`` are not NULL."""
+    return _rank(value) == _RANK_NULL
+
+
+def is_not_null(value: Value) -> bool:
+    """SQL ``IS NOT NULL``. Always a plain ``bool``, never ``None``."""
+    return not is_null(value)
+
+
+# --- Three-valued connectives --------------------------------------------
+#
+# Kleene logic, matching SQLite. Written as explicit tables rather than
+# short-circuiting expressions: this code is meant to be portable and
+# boring, and the NULL rows are exactly the ones that get reasoned about
+# wrongly.
+
+
+def and3(left: Bool3, right: Bool3) -> Bool3:
+    """SQL ``AND``. ``NULL AND FALSE`` is ``FALSE``; ``NULL AND TRUE``
+    and ``NULL AND NULL`` are ``NULL``."""
+    _check_bool3(left)
+    _check_bool3(right)
+    if left is False or right is False:
+        return False
+    if left is None or right is None:
+        return None
+    return True
+
+
+def or3(left: Bool3, right: Bool3) -> Bool3:
+    """SQL ``OR``. ``NULL OR TRUE`` is ``TRUE``; ``NULL OR FALSE`` and
+    ``NULL OR NULL`` are ``NULL``."""
+    _check_bool3(left)
+    _check_bool3(right)
+    if left is True or right is True:
+        return True
+    if left is None or right is None:
+        return None
+    return False
+
+
+def not3(result: Bool3) -> Bool3:
+    """SQL ``NOT``. ``NOT NULL`` is ``NULL``."""
+    _check_bool3(result)
+    if result is None:
+        return None
+    return not result
+
+
+# --- Ordering ------------------------------------------------------------
+
+
+def order_key(value: Value) -> tuple[int, int | float | str]:
+    """A total ordering key for ``ORDER BY``, usable as ``sorted(key=)``.
+
+    Returns ``(class_rank, payload)``. Every value gets a position -
+    nothing is ever left out and no part of the key is ``None``, so a
+    column of all NULLs sorts as happily as any other. NULL sorts first,
+    then numerics, then text, matching SQLite.
+
+    ``DESC`` is this ordering reversed; see the module docstring.
+    """
+    rank = _rank(value)
+    if rank == _RANK_NULL:
+        # Any constant will do - all NULLs tie with each other and the
+        # rank already separates them from everything else. 0 keeps the
+        # payload slot the same type family as the numeric case.
+        return (_RANK_NULL, 0)
+    return (rank, value)

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -1,0 +1,421 @@
+"""Tests for historian.values.
+
+Every expected value in this file was checked against the `sqlite3`
+command-line tool (3.51.0) rather than reasoned about from memory, per
+the project rule that SQLite is the definition of correct. The query
+used is quoted above each group.
+"""
+
+import pytest
+
+from historian.values import (
+    Bool3,
+    Value,
+    and3,
+    eq,
+    ge,
+    gt,
+    is_,
+    is_not,
+    is_not_null,
+    is_null,
+    is_true,
+    le,
+    lt,
+    ne,
+    not3,
+    or3,
+    order_key,
+)
+
+COMPARISONS = [eq, ne, lt, le, gt, ge]
+
+
+# --- Value representation ------------------------------------------------
+
+
+def test_value_alias_is_the_four_storage_classes():
+    """`Value` is `None | int | float | str` - SQLite's NULL/INTEGER/
+    REAL/TEXT. No bool, no bytes."""
+    assert Value == (None | int | float | str)
+
+
+def test_bool3_alias_is_bool_or_none():
+    assert Bool3 == (bool | None)
+
+
+@pytest.mark.parametrize("func", COMPARISONS + [is_, is_not])
+@pytest.mark.parametrize("bad", [True, False])
+def test_comparisons_reject_bool_operands(func, bad):
+    """bool is a subclass of int, so a Bool3 that leaks into a Value
+    position would silently compare as 1 or 0 and every isinstance check
+    would pass. The guard makes that loud instead."""
+    with pytest.raises(TypeError):
+        func(bad, 1)
+    with pytest.raises(TypeError):
+        func(1, bad)
+
+
+@pytest.mark.parametrize("func", [is_null, is_not_null, order_key])
+@pytest.mark.parametrize("bad", [True, False])
+def test_unary_value_functions_reject_bool(func, bad):
+    with pytest.raises(TypeError):
+        func(bad)
+
+
+@pytest.mark.parametrize("func", COMPARISONS)
+def test_comparisons_reject_unsupported_types(func):
+    with pytest.raises(TypeError):
+        func(b"bytes", 1)
+
+
+@pytest.mark.parametrize("func", [and3, or3])
+@pytest.mark.parametrize("bad", [1, 0, "x", 1.0])
+def test_connectives_reject_non_bool3(func, bad):
+    """SQLite's own representation of a predicate is 0/1/NULL. Ours is
+    False/True/None, and accepting the integers would blur the two."""
+    with pytest.raises(TypeError):
+        func(bad, True)
+    with pytest.raises(TypeError):
+        func(True, bad)
+
+
+@pytest.mark.parametrize("bad", [1, 0, "x", 1.0])
+def test_not3_rejects_non_bool3(bad):
+    with pytest.raises(TypeError):
+        not3(bad)
+
+
+# --- is_true: the WHERE / HAVING gate ------------------------------------
+
+
+def test_is_true_keeps_only_true():
+    """`WHERE` keeps a row only when the predicate is TRUE; FALSE and
+    NULL are both rejected, and confusing the two is the classic bug."""
+    assert is_true(True) is True
+    assert is_true(False) is False
+    assert is_true(None) is False
+
+
+# --- Comparisons: NULL propagation ---------------------------------------
+
+# sqlite3 :memory: "select quote(null = null), quote(null < 1),
+#   quote(1 < null), quote(null <> 1), quote(null <= 1),
+#   quote(null >= 1), quote(null > 1), quote(null != 1);"
+#   -> NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL
+
+
+@pytest.mark.parametrize("func", COMPARISONS)
+@pytest.mark.parametrize("other", [None, 1, 1.5, "", "abc", 0])
+def test_every_comparison_is_null_when_either_operand_is_null(func, other):
+    assert func(None, other) is None
+    assert func(other, None) is None
+
+
+# --- Comparisons: same storage class -------------------------------------
+
+# sqlite3 :memory: "select 1 = 1.0, 1 < 1.0, 1 <= 1.0, 2 > 1.9999,
+#   -0.0 = 0;" -> 1|0|1|1|1
+
+
+def test_int_and_float_compare_by_numeric_value():
+    assert eq(1, 1.0) is True
+    assert ne(1, 1.0) is False
+    assert lt(1, 1.0) is False
+    assert le(1, 1.0) is True
+    assert gt(1, 1.0) is False
+    assert ge(1, 1.0) is True
+    assert gt(2, 1.9999) is True
+    assert eq(-0.0, 0) is True
+
+
+def test_large_int_versus_real_compares_exactly():
+    """sqlite3 "select 9007199254740993 = 9007199254740992.0,
+    ... < ..., ... > ...;" -> 0|0|1. SQLite compares an INTEGER against
+    a REAL exactly rather than casting the int to double, and Python's
+    int/float comparison does the same, so no special-casing is needed.
+    """
+    big, real = 9007199254740993, 9007199254740992.0
+    assert eq(big, real) is False
+    assert lt(big, real) is False
+    assert gt(big, real) is True
+
+
+def test_ints_and_floats_compare_normally():
+    assert lt(1, 2) is True
+    assert lt(2, 1) is False
+    assert eq(1, 1) is True
+    assert ne(1, 2) is True
+    assert le(2, 2) is True
+    assert ge(2, 3) is False
+
+
+# sqlite3 :memory: "select 'a' < 'b', 'Z' < 'a', 'abc' < 'abd',
+#   'é' < 'z', 'z' < 'é', '' < 'a';" -> 1|1|1|0|1|1
+
+
+def test_text_compares_bytewise():
+    assert lt("a", "b") is True
+    assert lt("Z", "a") is True
+    assert lt("abc", "abd") is True
+    assert lt("", "a") is True
+    assert eq("abc", "abc") is True
+    assert ne("abc", "abd") is True
+
+
+def test_text_comparison_is_bytewise_for_non_ascii():
+    """UTF-8 byte order coincides with code point order for all of
+    Unicode, so Python's default string ordering already matches
+    SQLite's BINARY collation. Pinned down rather than assumed."""
+    assert lt("é", "z") is False
+    assert lt("z", "é") is True
+    assert gt("é", "z") is True
+
+
+# --- Comparisons: across storage classes ---------------------------------
+
+# sqlite3 :memory: "select 999 < 'abc', 999 < '5', '5' < 999,
+#   999 = '999', 999 <> '999', -1 < '', '' < -1;"
+#   -> 1|1|0|0|1|1|0
+
+
+def test_every_number_orders_before_every_text():
+    assert lt(999, "abc") is True
+    assert lt(999, "5") is True
+    assert lt("5", 999) is False
+    assert gt("5", 999) is True
+    assert lt(-1, "") is True
+    assert lt("", -1) is False
+
+
+def test_cross_class_equality_is_false_not_null():
+    assert eq(999, "999") is False
+    assert ne(999, "999") is True
+    assert eq("5", 5) is False
+
+
+def test_no_column_affinity_coercion():
+    """`5 = '5'` is FALSE (sqlite3 -> 0), even though
+    `WHERE line_no = '5'` is TRUE against an INTEGER column (sqlite3 ->
+    1 row). Affinity needs the AST and the schema, so it lives in
+    exec/expression.py; this module implements value-to-value
+    comparison only. See _docs/spec.md §3 and _docs/decisions.md
+    2026-08-27."""
+    assert eq(5, "5") is False
+    assert eq("5", 5) is False
+    assert ne(5, "5") is True
+    assert lt(5, "5") is True
+
+
+# --- IS / IS NOT / IS NULL / IS NOT NULL ---------------------------------
+
+# sqlite3 :memory: "select null is null, 1 is null, 1 is 1.0, '1' is 1,
+#   null is not null, 1 is not 1.0, '1' is not 1;" -> 1|0|1|0|0|0|1
+
+
+def test_is_and_is_not_are_never_null():
+    assert is_(None, None) is True
+    assert is_(1, None) is False
+    assert is_(None, 1) is False
+    assert is_(1, 1.0) is True
+    assert is_("1", 1) is False
+    assert is_not(None, None) is False
+    assert is_not(1, 1.0) is False
+    assert is_not("1", 1) is True
+
+
+@pytest.mark.parametrize(
+    "left", [None, 0, 1, 0.0, 1.5, "", "abc", "é"]
+)
+@pytest.mark.parametrize(
+    "right", [None, 0, 1, 0.0, 1.5, "", "abc", "é"]
+)
+def test_is_and_is_not_return_plain_bool_for_every_pair(left, right):
+    result = is_(left, right)
+    assert result is True or result is False
+    assert is_not(left, right) is (not result)
+
+
+@pytest.mark.parametrize("value", [0, 0.0, "", -0.0, 1, "abc"])
+def test_falsy_but_not_null_values_are_not_null(value):
+    """sqlite3 "select 0 is null, 0.0 is null, '' is null;" -> 0|0|0."""
+    assert is_null(value) is False
+    assert is_not_null(value) is True
+
+
+def test_is_null_of_null():
+    assert is_null(None) is True
+    assert is_not_null(None) is False
+
+
+# --- Three-valued connectives --------------------------------------------
+
+# sqlite3 :memory: "select quote(1 and 1), quote(1 and 0),
+#   quote(1 and null), quote(0 and 1), quote(0 and 0), quote(0 and null),
+#   quote(null and 1), quote(null and 0), quote(null and null);"
+#   -> 1|0|NULL|0|0|0|NULL|0|NULL
+
+AND_TABLE = {
+    (True, True): True,
+    (True, False): False,
+    (True, None): None,
+    (False, True): False,
+    (False, False): False,
+    (False, None): False,
+    (None, True): None,
+    (None, False): False,
+    (None, None): None,
+}
+
+# sqlite3 :memory: "select quote(1 or 1), quote(1 or 0), quote(1 or null),
+#   quote(0 or 1), quote(0 or 0), quote(0 or null), quote(null or 1),
+#   quote(null or 0), quote(null or null);"
+#   -> 1|1|1|1|0|NULL|1|NULL|NULL
+
+OR_TABLE = {
+    (True, True): True,
+    (True, False): True,
+    (True, None): True,
+    (False, True): True,
+    (False, False): False,
+    (False, None): None,
+    (None, True): True,
+    (None, False): None,
+    (None, None): None,
+}
+
+
+@pytest.mark.parametrize("operands,expected", sorted(AND_TABLE.items(), key=str))
+def test_and3_full_truth_table(operands, expected):
+    left, right = operands
+    assert and3(left, right) is expected
+
+
+@pytest.mark.parametrize("operands,expected", sorted(OR_TABLE.items(), key=str))
+def test_or3_full_truth_table(operands, expected):
+    left, right = operands
+    assert or3(left, right) is expected
+
+
+def test_and3_and_or3_cover_all_nine_combinations():
+    assert len(AND_TABLE) == 9
+    assert len(OR_TABLE) == 9
+
+
+def test_not3_full_truth_table():
+    """sqlite3 "select quote(not 1), quote(not 0), quote(not null);"
+    -> 0|1|NULL."""
+    assert not3(True) is False
+    assert not3(False) is True
+    assert not3(None) is None
+
+
+# --- Ordering ------------------------------------------------------------
+
+# sqlite3 :memory: "create table t(x); insert into t
+#   values(null),(1),(2),(null),(3); select quote(x) from t order by x;"
+#   -> NULL NULL 1 2 3
+# ... order by x desc; -> 3 2 1 NULL NULL
+
+
+def test_order_key_never_returns_none_anywhere():
+    for value in [None, 0, 1, 1.5, -3, "", "abc", "é"]:
+        key = order_key(value)
+        assert isinstance(key, tuple)
+        assert all(part is not None for part in key)
+
+
+def test_nulls_sort_first_ascending():
+    column = [None, 1, 2, None, 3]
+    assert sorted(column, key=order_key) == [None, None, 1, 2, 3]
+
+
+def test_descending_is_the_ascending_list_reversed():
+    """sqlite3 confirms ORDER BY x DESC is exactly the ascending list
+    reversed, NULLs included - so Sort gets DESC by reversing and needs
+    no NULLS-LAST rule of its own."""
+    column = [None, 1, 2, None, 3]
+    ascending = sorted(column, key=order_key)
+    assert list(reversed(ascending)) == [3, 2, 1, None, None]
+
+
+def test_order_key_ranks_null_before_numeric_before_text():
+    """sqlite3 :memory: "create table t(x); insert into t
+    values('abc'),(null),(2),('5'),(1.5),(''); select quote(x) from t
+    order by x;" -> NULL 1.5 2 '' '5' 'abc'."""
+    column = ["abc", None, 2, "5", 1.5, ""]
+    assert sorted(column, key=order_key) == [None, 1.5, 2, "", "5", "abc"]
+    assert list(reversed(sorted(column, key=order_key))) == [
+        "abc",
+        "5",
+        "",
+        2,
+        1.5,
+        None,
+    ]
+
+
+def test_order_key_does_not_compare_int_against_str():
+    """A key that put values of different classes in the same tuple slot
+    would raise TypeError on mixed columns."""
+    assert order_key(1)[0] < order_key("1")[0]
+    assert order_key(None)[0] < order_key(1)[0]
+
+
+def test_order_key_is_deterministic():
+    for value in [None, 0, 1.5, "abc"]:
+        assert order_key(value) == order_key(value)
+
+
+# --- Grouping / DISTINCT equality ----------------------------------------
+
+# sqlite3 :memory: "create table t(x); insert into t
+#   values(null),(null),(1),(1),(2); select quote(x), count(*) from t
+#   group by x;" -> NULL|2, 1|2, 2|1
+# select distinct x  -> NULL, 1, 2 (one NULL row, not two)
+
+
+def test_raw_python_equality_implements_grouping_semantics():
+    assert (None == None) is True  # noqa: E711
+    assert (1 == 1.0) is True
+    assert hash(1) == hash(1.0)
+    assert ("1" == 1) is False
+
+
+def test_group_by_raw_value_produces_three_groups():
+    column = [None, None, 1, 1, 2]
+    groups: dict[Value, int] = {}
+    for value in column:
+        groups[value] = groups.get(value, 0) + 1
+    assert len(groups) == 3
+    assert groups[None] == 2
+    assert groups[1] == 2
+    assert groups[2] == 1
+
+
+def test_distinct_over_nulls_yields_exactly_one_null():
+    column = [None, None, 1, 1, 2]
+    distinct = list(dict.fromkeys(column))
+    assert distinct == [None, 1, 2]
+    assert distinct.count(None) == 1
+
+
+def test_grouping_by_the_eq_function_would_be_wrong():
+    """The wrong instinct is to key groups with `eq`. eq(NULL, NULL) is
+    NULL, which is falsy, so every NULL row would become its own group.
+    Asserted so the trap is recorded, not just described."""
+    assert eq(None, None) is None
+    assert not is_true(eq(None, None))
+    assert (None == None) is True  # noqa: E711
+
+
+def test_grouping_treats_int_and_equal_float_as_one_group():
+    """sqlite3 "insert into t values(1),(1.0),('1'); select quote(x),
+    count(*) from t group by x;" -> 1|2, '1'|1."""
+    column = [1, 1.0, "1"]
+    groups: dict[Value, int] = {}
+    for value in column:
+        groups[value] = groups.get(value, 0) + 1
+    assert len(groups) == 2
+    assert groups[1] == 2
+    assert groups["1"] == 1


### PR DESCRIPTION
Closes #2.

`historian.values` — the foundation everything else inherits. §6 of the spec calls this the task to slow down on, and the single largest source of differential mismatches later.

## What is here

`Value` is `None | int | float | str`, and `Bool3` is `bool | None`, with `None` doubling as both a NULL value and a NULL predicate result. Six comparison operators returning `Bool3`, `IS`/`IS NOT`/`IS NULL`/`IS NOT NULL` returning a plain `bool`, Kleene `AND`/`OR`/`NOT`, an `is_true()` gate for `WHERE`/`HAVING`, and `order_key()` for `ORDER BY`.

`order_key` is deliberately separate from the comparison operators: `ORDER BY` needs a total order with NULLs first, while `<` must return NULL. `sqlite3` confirms `DESC` is the ascending order exactly reversed, NULLs included, so `Sort` gets `DESC` for free from one ascending key.

## Verification

QA verdict: PASS on all 17 acceptance criteria — https://github.com/ionut-banu/historian/issues/2#issuecomment-5437312604

190 new tests, 192 in the suite. Every semantic claim was checked against `sqlite3` directly rather than reasoned about — by the engineer while implementing, and again independently by QA rather than trusting the engineer's tests, since a test encoding a misreading passes.

Both parties mutation-tested, with different mutations: removing the bool guard turned 22 tests red, flipping `is_`'s NULL branch turned 1 red, reordering `or3` turned 5 red.

Differential: n/a, no suite until M3. Fuzzer: n/a, not built until M5.

## Three things sqlite3 contradicted expectations on

**Integer/real comparison is exact, not a cast.** `9007199254740993 = 9007199254740992.0` is false and the `>` is true. Past 2^53 a double cannot hold consecutive integers, so a `float()` conversion reverses the answer. Python already agrees, so the fix was to add nothing — but a cast introduced later for convenience would break it silently. Recorded in the spec and pinned by a test.

**SQLite has no NaN.** `typeof(0.0/0.0)` is `null`, so a NaN can never be a stored value.

**`typeof(true)` is `integer`.** There is no boolean storage class, which independently confirms excluding `bool` from `Value` is required rather than tidy — and Python's `bool` being a subclass of `int` makes it a real hazard, so every function raises `TypeError` on a `bool` in a `Value` position, checked before the `int` branch.

## Deliberately absent

Column affinity. `5 = '5'` is false here, but `WHERE line_no = '5'` is true against an INTEGER column — this module cannot see columns or declared types. It belongs to `exec/expression.py`, recorded in the spec and the decisions log, with a named test asserting the abstention so it reads as a decision rather than a gap.