### PR TITLE
SQL lexer (#3)

### DIFF
--- a/src/historian/sql/lexer.py
+++ b/src/historian/sql/lexer.py
@@ -1,0 +1,456 @@
+"""SQL text -> tokens.
+
+The first stage of the pipeline in `_docs/spec.md` §3. Every token
+carries a `Position` so that a query the parser cannot make sense of -
+and later, a query the binder cannot resolve - can be reported pointing
+at the offending character, per §5's error format, rather than as a
+traceback.
+
+Positions are character-based, not byte-based
+----------------------------------------------
+
+`Position.offset` is a Unicode code-point index into the source string
+(`len()`/slicing semantics), and `Position.column` counts code points
+too. Query text - and the `blame.line` values that end up embedded in
+it inside string literals - can contain non-ASCII characters, and a
+byte offset would silently misalign the `^` in §5's error display the
+first time one appeared before the error column. Python strings already
+index by code point, so this is "don't convert to bytes anywhere," not
+new machinery.
+
+Token type set
+--------------
+
+One `TokenType` member per v1 keyword (`TokenType.SELECT`, not a shared
+`KEYWORD` type carrying text) - see `_docs/decisions.md`, 2026-08-27,
+"One token type per keyword, not a shared KEYWORD type". A mistyped
+keyword literal at a parser call site (`TokenType.SELCT`) then fails
+loud, as `AttributeError` at import, instead of silently never matching
+a shared type's text comparison.
+
+Aggregate and scalar function names (`count`, `sum`, ...) are
+deliberately not keywords - they lex as plain `IDENTIFIER`, and it is
+the parser's job to recognise `IDENTIFIER LPAREN` as a call. SQLite
+allows a column named `count`; making it a keyword here would take that
+away before the parser gets a say.
+
+Which errors are the lexer's
+-----------------------------
+
+`LexError` is raised for exactly three things, each confirmed against
+`sqlite3` rather than assumed: an unterminated single-quoted string, an
+unterminated double-quoted identifier, and a character that starts no
+valid v1 token. An identifier that is not a keyword, or is not a real
+column, is not a lexer error - that is `sql/binder.py`'s job, and it
+needs schema context this module never has.
+
+Not in this module
+-------------------
+
+Parsing, precedence, and any tree structure (`sql/parser.py`).
+Scientific notation (`1e10`), hex integers (`0x1F`), `==` as an alias
+for `=`, and `/* */` block comments are real SQLite syntax but are not
+part of the v1 grammar in §1 - deferred to issue #6. Boolean literals
+are deferred too; `historian.values.Value` deliberately excludes `bool`
+(see its module docstring).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+__all__ = [
+    "KEYWORD_TYPES",
+    "LexError",
+    "Position",
+    "Token",
+    "TokenType",
+    "is_keyword",
+    "tokenize",
+]
+
+
+class TokenType(Enum):
+    """Every kind of token the v1 grammar can produce.
+
+    Keywords each get their own member (see the module docstring); the
+    rest are one member per literal kind or punctuation mark, plus a
+    single `EOF` that always terminates the stream so the parser never
+    has to special-case running off the end.
+    """
+
+    # Keywords - the v1 grammar's closed 30-keyword set (_docs/spec.md §1).
+    SELECT = auto()
+    DISTINCT = auto()
+    AS = auto()
+    FROM = auto()
+    INNER = auto()
+    JOIN = auto()
+    ON = auto()
+    USING = auto()
+    WHERE = auto()
+    GROUP = auto()
+    BY = auto()
+    HAVING = auto()
+    ORDER = auto()
+    ASC = auto()
+    DESC = auto()
+    LIMIT = auto()
+    OFFSET = auto()
+    AND = auto()
+    OR = auto()
+    NOT = auto()
+    LIKE = auto()
+    IN = auto()
+    BETWEEN = auto()
+    IS = auto()
+    NULL = auto()
+    CASE = auto()
+    WHEN = auto()
+    THEN = auto()
+    ELSE = auto()
+    END = auto()
+
+    # Literals and names.
+    IDENTIFIER = auto()
+    STRING = auto()
+    INTEGER = auto()
+    REAL = auto()
+
+    # Operators and punctuation.
+    EQ = auto()  # =
+    NE = auto()  # <> or !=
+    LT = auto()  # <
+    LE = auto()  # <=
+    GT = auto()  # >
+    GE = auto()  # >=
+    PLUS = auto()  # +
+    MINUS = auto()  # -
+    STAR = auto()  # *
+    SLASH = auto()  # /
+    CONCAT = auto()  # ||
+    LPAREN = auto()  # (
+    RPAREN = auto()  # )
+    COMMA = auto()  # ,
+    DOT = auto()  # .
+    SEMICOLON = auto()  # ;
+
+    EOF = auto()
+
+
+#: The keyword `TokenType` members, exactly - a test in `tests/
+#: test_lexer.py` asserts this set equals the v1 grammar's 30-keyword
+#: list, so a keyword added to the grammar later that the lexer forgets
+#: to wire up fails a test here rather than surfacing as a silent parse
+#: gap.
+KEYWORD_TYPES: frozenset[TokenType] = frozenset(
+    {
+        TokenType.SELECT,
+        TokenType.DISTINCT,
+        TokenType.AS,
+        TokenType.FROM,
+        TokenType.INNER,
+        TokenType.JOIN,
+        TokenType.ON,
+        TokenType.USING,
+        TokenType.WHERE,
+        TokenType.GROUP,
+        TokenType.BY,
+        TokenType.HAVING,
+        TokenType.ORDER,
+        TokenType.ASC,
+        TokenType.DESC,
+        TokenType.LIMIT,
+        TokenType.OFFSET,
+        TokenType.AND,
+        TokenType.OR,
+        TokenType.NOT,
+        TokenType.LIKE,
+        TokenType.IN,
+        TokenType.BETWEEN,
+        TokenType.IS,
+        TokenType.NULL,
+        TokenType.CASE,
+        TokenType.WHEN,
+        TokenType.THEN,
+        TokenType.ELSE,
+        TokenType.END,
+    }
+)
+
+# Keyword text (uppercase) -> TokenType, for case-insensitive lookup of a
+# scanned identifier against the keyword set.
+_KEYWORDS_BY_TEXT: dict[str, TokenType] = {
+    member.name: member for member in KEYWORD_TYPES
+}
+
+
+def is_keyword(token_type: TokenType) -> bool:
+    """Is *token_type* one of the 30 v1 keywords?
+
+    The escape hatch for call sites that need "any keyword," not one in
+    particular - an error message, or a check for whether a token can
+    start a clause - so they don't have to enumerate all thirty members
+    or fall back to string comparison against `token.text`.
+    """
+    return token_type in KEYWORD_TYPES
+
+
+@dataclass(frozen=True)
+class Position:
+    """A location in SQL source text, in Unicode code points.
+
+    `line` is 1-based. `column` is 1-based, counted in code points, not
+    bytes. `offset` is a 0-based code-point index into the source string
+    - `len()`/slicing semantics. A token's position is the position of
+    its first character.
+    """
+
+    line: int
+    column: int
+    offset: int
+
+
+@dataclass(frozen=True)
+class Token:
+    """One lexical token: its type, its decoded text, and where it
+    starts in the source.
+
+    `text` is the token's decoded value - quotes stripped and escapes
+    un-escaped for `STRING` and quoted `IDENTIFIER`, the keyword's own
+    spelling as written for keywords, the digits as written for numeric
+    literals. There is no separate field recording whether an identifier
+    was quoted; the parser and binder never need to know.
+    """
+
+    type: TokenType
+    text: str
+    position: Position
+
+
+class LexError(Exception):
+    """The source text contains something no v1 token can start with,
+    or a string/quoted-identifier literal that is never closed.
+
+    Carries the message and the `Position` at which the problem starts
+    - the opening quote for an unterminated literal, the offending
+    character itself for everything else - so a caller can report it
+    per `_docs/spec.md` §5 without re-deriving the location.
+    """
+
+    def __init__(self, message: str, position: Position) -> None:
+        super().__init__(message)
+        self.position = position
+
+
+def tokenize(source: str) -> list[Token]:
+    """Turn *source* into a list of tokens, always ending with `EOF`.
+
+    Pure function of its argument: the same source string always
+    produces the same token stream (`AGENTS.md`'s determinism rule).
+    Raises `LexError` for an unterminated string, an unterminated
+    quoted identifier, or a character that starts no valid token.
+    """
+    return _Lexer(source).run()
+
+
+_WHITESPACE = " \t\r"
+
+
+class _Lexer:
+    """Single-pass scanner over `source`, tracking line/column/offset by
+    hand so every token's `Position` is exact."""
+
+    def __init__(self, source: str) -> None:
+        self._source = source
+        self._length = len(source)
+        self._pos = 0
+        self._line = 1
+        self._column = 1
+
+    # -- low-level cursor movement ----------------------------------
+
+    def _at_end(self) -> bool:
+        return self._pos >= self._length
+
+    def _peek(self, ahead: int = 0) -> str:
+        index = self._pos + ahead
+        if index >= self._length:
+            return ""
+        return self._source[index]
+
+    def _position(self) -> Position:
+        return Position(line=self._line, column=self._column, offset=self._pos)
+
+    def _advance(self) -> str:
+        """Consume and return the current character, updating line and
+        column. `\\n` starts a new line; every other character - including
+        other whitespace - advances the column by one."""
+        char = self._source[self._pos]
+        self._pos += 1
+        if char == "\n":
+            self._line += 1
+            self._column = 1
+        else:
+            self._column += 1
+        return char
+
+    # -- driver -------------------------------------------------------
+
+    def run(self) -> list[Token]:
+        tokens: list[Token] = []
+        while True:
+            self._skip_whitespace_and_comments()
+            start = self._position()
+            if self._at_end():
+                tokens.append(Token(TokenType.EOF, "", start))
+                return tokens
+            tokens.append(self._next_token(start))
+
+    def _skip_whitespace_and_comments(self) -> None:
+        while not self._at_end():
+            char = self._peek()
+            if char in _WHITESPACE or char == "\n":
+                self._advance()
+                continue
+            if char == "-" and self._peek(1) == "-":
+                self._advance()
+                self._advance()
+                while not self._at_end() and self._peek() != "\n":
+                    self._advance()
+                continue
+            break
+
+    def _next_token(self, start: Position) -> Token:
+        char = self._peek()
+
+        if char == "'":
+            return self._read_string(start)
+        if char == '"':
+            return self._read_quoted_identifier(start)
+        if char.isdigit():
+            return self._read_number(start)
+        if char == "." and self._peek(1).isdigit():
+            return self._read_number(start)
+        if char.isalpha() or char == "_":
+            return self._read_identifier(start)
+
+        return self._read_operator(start)
+
+    # -- string and quoted-identifier literals -------------------------
+
+    def _read_string(self, start: Position) -> Token:
+        self._advance()  # opening '
+        chars: list[str] = []
+        while True:
+            if self._at_end():
+                raise LexError(
+                    "unterminated string literal starting at "
+                    f"line {start.line}, column {start.column}",
+                    start,
+                )
+            char = self._advance()
+            if char == "'":
+                if self._peek() == "'":
+                    self._advance()
+                    chars.append("'")
+                    continue
+                break
+            chars.append(char)
+        return Token(TokenType.STRING, "".join(chars), start)
+
+    def _read_quoted_identifier(self, start: Position) -> Token:
+        self._advance()  # opening "
+        chars: list[str] = []
+        while True:
+            if self._at_end():
+                raise LexError(
+                    "unterminated quoted identifier starting at "
+                    f"line {start.line}, column {start.column}",
+                    start,
+                )
+            char = self._advance()
+            if char == '"':
+                if self._peek() == '"':
+                    self._advance()
+                    chars.append('"')
+                    continue
+                break
+            chars.append(char)
+        return Token(TokenType.IDENTIFIER, "".join(chars), start)
+
+    # -- numeric literals ------------------------------------------------
+
+    def _read_number(self, start: Position) -> Token:
+        chars: list[str] = []
+        is_real = False
+        while self._peek().isdigit():
+            chars.append(self._advance())
+        if self._peek() == ".":
+            is_real = True
+            chars.append(self._advance())
+            while self._peek().isdigit():
+                chars.append(self._advance())
+        token_type = TokenType.REAL if is_real else TokenType.INTEGER
+        return Token(token_type, "".join(chars), start)
+
+    # -- identifiers and keywords -----------------------------------
+
+    def _read_identifier(self, start: Position) -> Token:
+        chars: list[str] = []
+        while self._peek().isalnum() or self._peek() == "_":
+            chars.append(self._advance())
+        text = "".join(chars)
+        keyword_type = _KEYWORDS_BY_TEXT.get(text.upper())
+        if keyword_type is not None:
+            return Token(keyword_type, text, start)
+        return Token(TokenType.IDENTIFIER, text, start)
+
+    # -- operators and punctuation -------------------------------------
+
+    _TWO_CHAR_OPERATORS = {
+        "<>": TokenType.NE,
+        "!=": TokenType.NE,
+        "<=": TokenType.LE,
+        ">=": TokenType.GE,
+        "||": TokenType.CONCAT,
+    }
+
+    _ONE_CHAR_OPERATORS = {
+        "=": TokenType.EQ,
+        "<": TokenType.LT,
+        ">": TokenType.GT,
+        "+": TokenType.PLUS,
+        "-": TokenType.MINUS,
+        "*": TokenType.STAR,
+        "/": TokenType.SLASH,
+        "(": TokenType.LPAREN,
+        ")": TokenType.RPAREN,
+        ",": TokenType.COMMA,
+        ".": TokenType.DOT,
+        ";": TokenType.SEMICOLON,
+    }
+
+    def _read_operator(self, start: Position) -> Token:
+        two_char = self._peek() + self._peek(1)
+        token_type = self._TWO_CHAR_OPERATORS.get(two_char)
+        if token_type is not None:
+            self._advance()
+            self._advance()
+            return Token(token_type, two_char, start)
+
+        char = self._peek()
+        token_type = self._ONE_CHAR_OPERATORS.get(char)
+        if token_type is not None:
+            self._advance()
+            return Token(token_type, char, start)
+
+        # `!` not followed by `=` (handled above as `NE`) starts no valid
+        # v1 token, the same as any other unrecognised character.
+        self._advance()
+        raise LexError(
+            f"unexpected character {char!r} at line {start.line}, "
+            f"column {start.column}",
+            start,
+        )

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,0 +1,447 @@
+"""Tests for historian.sql.lexer.
+
+Expected values for anything with a plausible SQLite answer (string/
+identifier escaping, numeric literal forms, comment syntax) were checked
+against the `sqlite3` command-line tool (3.51.0) rather than reasoned
+about from memory, per the project rule that SQLite is the definition of
+correct. The query used is quoted above each group, same convention as
+`tests/test_values.py`.
+"""
+
+import pytest
+
+from historian.sql.lexer import (
+    KEYWORD_TYPES,
+    LexError,
+    Position,
+    Token,
+    TokenType,
+    is_keyword,
+    tokenize,
+)
+
+# The v1 keyword set, per _docs/spec.md §1 and issue #3. Hand-written and
+# independent of TokenType's own membership, so a keyword silently
+# dropped from the enum turns this test red rather than passing by
+# comparing the enum against itself.
+V1_KEYWORDS = {
+    "SELECT", "DISTINCT", "AS", "FROM", "INNER", "JOIN", "ON", "USING",
+    "WHERE", "GROUP", "BY", "HAVING", "ORDER", "ASC", "DESC", "LIMIT",
+    "OFFSET", "AND", "OR", "NOT", "LIKE", "IN", "BETWEEN", "IS", "NULL",
+    "CASE", "WHEN", "THEN", "ELSE", "END",
+}
+
+
+def _types(tokens):
+    return [t.type for t in tokens]
+
+
+def _texts(tokens):
+    return [t.text for t in tokens]
+
+
+# --- tokenize() basics -----------------------------------------------
+
+
+def test_empty_source_is_a_single_eof_token():
+    tokens = tokenize("")
+    assert _types(tokens) == [TokenType.EOF]
+
+
+def test_stream_always_ends_with_eof():
+    tokens = tokenize("SELECT")
+    assert tokens[-1].type is TokenType.EOF
+
+
+def test_every_token_has_type_text_and_position():
+    tokens = tokenize("SELECT")
+    tok = tokens[0]
+    assert tok.type is TokenType.SELECT
+    assert tok.text == "SELECT"
+    assert isinstance(tok.position, Position)
+
+
+# --- Keywords ----------------------------------------------------------
+
+
+def test_keyword_type_set_matches_v1_grammar_exactly():
+    assert KEYWORD_TYPES == {TokenType[name] for name in V1_KEYWORDS}
+
+
+@pytest.mark.parametrize("keyword", sorted(V1_KEYWORDS))
+def test_each_keyword_lexes_to_its_own_token_type(keyword):
+    for spelling in (keyword, keyword.lower(), keyword.title()):
+        tokens = tokenize(spelling)
+        assert tokens[0].type is TokenType[keyword]
+        assert tokens[0].text == spelling
+
+
+def test_is_keyword_true_for_exactly_the_keyword_types():
+    for member in TokenType:
+        expected = member in KEYWORD_TYPES
+        assert is_keyword(member) is expected
+
+
+def test_is_keyword_false_for_eof_and_identifier():
+    assert is_keyword(TokenType.EOF) is False
+    assert is_keyword(TokenType.IDENTIFIER) is False
+
+
+# --- Identifiers ---------------------------------------------------------
+
+
+def test_bare_identifier_preserves_original_case():
+    tokens = tokenize("MyColumn")
+    assert tokens[0].type is TokenType.IDENTIFIER
+    assert tokens[0].text == "MyColumn"
+
+
+def test_identifier_that_is_not_a_keyword_lexes_as_identifier():
+    tokens = tokenize("count")
+    assert tokens[0].type is TokenType.IDENTIFIER
+    assert tokens[0].text == "count"
+
+
+def test_double_quoted_identifier_strips_quotes():
+    tokens = tokenize('"path"')
+    assert tokens[0].type is TokenType.IDENTIFIER
+    assert tokens[0].text == "path"
+
+
+def test_double_quoted_identifier_decodes_doubled_quote():
+    # sqlite3: create table t("a""b" int); -- accepted, column named a"b
+    tokens = tokenize('"a""b"')
+    assert tokens[0].type is TokenType.IDENTIFIER
+    assert tokens[0].text == 'a"b'
+
+
+def test_double_quoted_keyword_spelling_lexes_as_identifier_not_keyword():
+    tokens = tokenize('"select"')
+    assert tokens[0].type is TokenType.IDENTIFIER
+    assert tokens[0].text == "select"
+
+
+def test_unterminated_double_quoted_identifier_raises_at_opening_quote():
+    with pytest.raises(LexError) as exc_info:
+        tokenize('SELECT "abc FROM t')
+    assert exc_info.value.position.offset == 7
+
+
+# --- Strings ---------------------------------------------------------
+
+
+def test_single_quoted_string_strips_quotes():
+    tokens = tokenize("'hello'")
+    assert tokens[0].type is TokenType.STRING
+    assert tokens[0].text == "hello"
+
+
+def test_single_quoted_string_decodes_doubled_quote():
+    # sqlite3: select 'it''s'; -> it's
+    tokens = tokenize("'it''s'")
+    assert tokens[0].type is TokenType.STRING
+    assert tokens[0].text == "it's"
+
+
+def test_unterminated_string_raises_at_opening_quote():
+    # sqlite3: select 'abc  ->  Error: unrecognized token: "'abc"
+    with pytest.raises(LexError) as exc_info:
+        tokenize("SELECT 'abc")
+    assert exc_info.value.position.offset == 7
+    assert exc_info.value.position.column == 8
+
+
+# --- Numeric literals ------------------------------------------------
+
+
+def test_integer_lexes_as_integer():
+    tokens = tokenize("42")
+    assert tokens[0].type is TokenType.INTEGER
+    assert tokens[0].text == "42"
+
+
+@pytest.mark.parametrize(
+    "source",
+    ["5.5", "5.", ".5"],
+    # sqlite3: select 5.5, 5., .5, typeof(5.), typeof(.5);
+    #   -> 5.5|5.0|0.5|real|real -- all three are valid reals
+)
+def test_real_forms_lex_as_a_single_real_token(source):
+    tokens = tokenize(source)
+    assert _types(tokens) == [TokenType.REAL, TokenType.EOF]
+    assert tokens[0].text == source
+
+
+def test_scientific_notation_is_not_a_single_token_in_v1():
+    """1e10 is real SQLite syntax but out of scope for this issue (#6).
+    It lexes as INTEGER "1" followed by IDENTIFIER "e10"."""
+    tokens = tokenize("1e10")
+    assert _types(tokens) == [
+        TokenType.INTEGER,
+        TokenType.IDENTIFIER,
+        TokenType.EOF,
+    ]
+    assert _texts(tokens)[:2] == ["1", "e10"]
+
+
+def test_hex_integer_is_not_a_single_token_in_v1():
+    """0x1F is real SQLite syntax but out of scope for this issue (#6).
+    It lexes as INTEGER "0" followed by IDENTIFIER "x1F"."""
+    tokens = tokenize("0x1F")
+    assert _types(tokens) == [
+        TokenType.INTEGER,
+        TokenType.IDENTIFIER,
+        TokenType.EOF,
+    ]
+    assert _texts(tokens)[:2] == ["0", "x1F"]
+
+
+def test_sign_is_not_part_of_a_numeric_token():
+    tokens = tokenize("-5")
+    assert _types(tokens) == [TokenType.MINUS, TokenType.INTEGER, TokenType.EOF]
+
+
+# --- Operators and maximal munch --------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source,expected_type",
+    [
+        ("<>", TokenType.NE),
+        ("!=", TokenType.NE),
+        ("<=", TokenType.LE),
+        (">=", TokenType.GE),
+        ("||", TokenType.CONCAT),
+    ],
+)
+def test_two_character_operators_lex_as_one_token(source, expected_type):
+    tokens = tokenize(source)
+    # A count assertion, not just "the type appears somewhere" - this is
+    # exactly the check that would fail if munch order were wrong and
+    # the lexer emitted two single-character tokens instead.
+    assert _types(tokens) == [expected_type, TokenType.EOF]
+
+
+@pytest.mark.parametrize(
+    "source,expected_type",
+    [("<", TokenType.LT), (">", TokenType.GT), ("=", TokenType.EQ)],
+)
+def test_single_character_operators_not_followed_by_pairing_char(
+    source, expected_type
+):
+    tokens = tokenize(source)
+    assert _types(tokens) == [expected_type, TokenType.EOF]
+
+
+def test_double_equals_lexes_as_two_eq_tokens():
+    """SQLite accepts == as an alias for =, but §1's grammar doesn't, so
+    == is deliberately left as two adjacent EQ tokens (#6)."""
+    tokens = tokenize("==")
+    assert _types(tokens) == [TokenType.EQ, TokenType.EQ, TokenType.EOF]
+
+
+def test_all_punctuation_tokens():
+    source = "+ - * / ( ) , . ;"
+    tokens = tokenize(source)
+    assert _types(tokens) == [
+        TokenType.PLUS,
+        TokenType.MINUS,
+        TokenType.STAR,
+        TokenType.SLASH,
+        TokenType.LPAREN,
+        TokenType.RPAREN,
+        TokenType.COMMA,
+        TokenType.DOT,
+        TokenType.SEMICOLON,
+        TokenType.EOF,
+    ]
+
+
+# --- Comments ----------------------------------------------------------
+
+
+def test_line_comment_runs_to_end_of_line():
+    tokens = tokenize("SELECT 1 -- this is a comment\nFROM t")
+    assert _types(tokens) == [
+        TokenType.SELECT,
+        TokenType.INTEGER,
+        TokenType.FROM,
+        TokenType.IDENTIFIER,
+        TokenType.EOF,
+    ]
+
+
+def test_line_comment_runs_to_end_of_input_with_no_trailing_newline():
+    tokens = tokenize("SELECT 1 -- trailing comment, no newline")
+    assert _types(tokens) == [TokenType.SELECT, TokenType.INTEGER, TokenType.EOF]
+
+
+def test_source_of_only_whitespace_and_comments_is_a_single_eof():
+    tokens = tokenize("  \n-- just a comment\n  \n")
+    assert _types(tokens) == [TokenType.EOF]
+
+
+def test_block_comment_is_not_supported_in_v1():
+    """/* */ is out of scope for this issue (#6): / lexes as SLASH and
+    * as STAR, not as a comment delimiter."""
+    tokens = tokenize("/* not a comment */")
+    assert _types(tokens) == [
+        TokenType.SLASH,
+        TokenType.STAR,
+        TokenType.NOT,
+        TokenType.IDENTIFIER,
+        TokenType.IDENTIFIER,
+        TokenType.STAR,
+        TokenType.SLASH,
+        TokenType.EOF,
+    ]
+
+
+# --- Illegal characters -------------------------------------------------
+
+
+def test_unrecognised_character_raises_lex_error_naming_the_character():
+    with pytest.raises(LexError) as exc_info:
+        tokenize("SELECT @foo")
+    assert "@" in str(exc_info.value)
+    assert exc_info.value.position.offset == 7
+
+
+@pytest.mark.parametrize("char", ["@", "#", "$", "`"])
+def test_various_unrecognised_characters_raise(char):
+    with pytest.raises(LexError):
+        tokenize(char)
+
+
+def test_bang_not_followed_by_equals_raises():
+    with pytest.raises(LexError):
+        tokenize("!")
+
+
+# --- Positions -----------------------------------------------------------
+
+
+def test_position_offset_is_code_point_index_not_byte_index():
+    # 'é' is one code point but two UTF-8 bytes; 'x' must sit at offset
+    # 2 (after "é'"), not offset 3, which is what a byte-counting lexer
+    # would produce.
+    source = "'é' x"
+    tokens = tokenize(source)
+    assert tokens[0].type is TokenType.STRING
+    assert tokens[0].position.offset == 0
+    ident = tokens[1]
+    assert ident.type is TokenType.IDENTIFIER
+    assert ident.text == "x"
+    assert ident.position.offset == 4
+    assert ident.position.column == 5
+
+
+def test_position_offset_multibyte_cjk():
+    # "日本語" is three code points (nine UTF-8 bytes). The token after
+    # the closing quote must be at code-point offset 5, not 11.
+    source = "'日本語' y"
+    tokens = tokenize(source)
+    ident = tokens[1]
+    assert ident.text == "y"
+    assert ident.position.offset == 6
+    assert ident.position.column == 7
+
+
+def test_token_position_is_first_character_of_token():
+    tokens = tokenize("  SELECT")
+    assert tokens[0].position.offset == 2
+    assert tokens[0].position.column == 3
+    assert tokens[0].position.line == 1
+
+
+def test_line_and_column_after_embedded_newline():
+    source = "SELECT a\nFROM b"
+    tokens = tokenize(source)
+    from_token = tokens[2]
+    assert from_token.type is TokenType.FROM
+    assert from_token.position.line == 2
+    assert from_token.position.column == 1
+    b_token = tokens[3]
+    assert b_token.position.line == 2
+    assert b_token.position.column == 6
+
+
+def test_line_and_column_after_multiple_newlines():
+    source = "SELECT\n\n  a"
+    tokens = tokenize(source)
+    a_token = tokens[1]
+    assert a_token.type is TokenType.IDENTIFIER
+    assert a_token.position.line == 3
+    assert a_token.position.column == 3
+
+
+def test_newline_inside_string_still_advances_line_tracking():
+    """A v1 token cannot itself span a newline (strings and identifiers
+    don't in SQLite either - confirmed: a bare embedded newline inside a
+    single-quoted string is legal SQL and does not end the string, but
+    since our unterminated-string check only fires at end-of-input, a
+    string containing a literal newline is representable; what matters
+    here is that line/column tracking resumes correctly for tokens after
+    it)."""
+    source = "'a\nb' c"
+    tokens = tokenize(source)
+    assert tokens[0].type is TokenType.STRING
+    assert tokens[0].text == "a\nb"
+    ident = tokens[1]
+    assert ident.text == "c"
+    assert ident.position.line == 2
+    assert ident.position.column == 4
+
+
+def test_carriage_return_and_tab_advance_column_not_line():
+    source = "a\tb"
+    tokens = tokenize(source)
+    b_token = tokens[1]
+    assert b_token.position.line == 1
+    assert b_token.position.column == 3
+
+
+# --- Determinism -----------------------------------------------------
+
+
+def test_tokenizing_same_source_twice_is_equal():
+    source = "SELECT a, b FROM t WHERE a = 1 -- comment\n"
+    assert tokenize(source) == tokenize(source)
+
+
+def test_tokenizing_same_source_twice_is_equal_with_errors_absent():
+    source = "SELECT * FROM blame WHERE path LIKE 'src/%' LIMIT 10"
+    first = tokenize(source)
+    second = tokenize(source)
+    assert first == second
+    assert first is not second
+
+
+# --- Realistic query, end to end ---------------------------------------
+
+
+def test_realistic_query_tokenizes_as_expected():
+    source = "SELECT author_name, count(*) FROM blame WHERE path LIKE 'src/auth/%' GROUP BY author_name"
+    tokens = tokenize(source)
+    assert _types(tokens) == [
+        TokenType.SELECT,
+        TokenType.IDENTIFIER,
+        TokenType.COMMA,
+        TokenType.IDENTIFIER,
+        TokenType.LPAREN,
+        TokenType.STAR,
+        TokenType.RPAREN,
+        TokenType.FROM,
+        TokenType.IDENTIFIER,
+        TokenType.WHERE,
+        TokenType.IDENTIFIER,
+        TokenType.LIKE,
+        TokenType.STRING,
+        TokenType.GROUP,
+        TokenType.BY,
+        TokenType.IDENTIFIER,
+        TokenType.EOF,
+    ]
+    string_tokens = [t for t in tokens if t.type is TokenType.STRING]
+    assert len(string_tokens) == 1
+    assert string_tokens[0].text == "src/auth/%"


### PR DESCRIPTION
Closes #3. Last issue of M1.

`historian.sql.lexer` — SQL text to a token stream, with positions good enough for §5's error carets.

## What is here

`tokenize(source) -> list[Token]`, a `TokenType` with one member per keyword, `KEYWORD_TYPES`/`is_keyword()`, a character-based `Position`, and a positioned `LexError`. Maximal munch on operators, quote-doubling escapes for both strings and identifiers, the three real-literal forms, and `--` line comments.

## Two decisions worth knowing about

**One `TokenType` member per keyword**, rather than a shared `KEYWORD` type carrying text. The PM chose the latter and the orchestrator overruled it: with a shared type the parser matches `tok.type is KEYWORD and tok.text == "SELECT"`, where a mistyped literal silently never matches and surfaces later as a confusing parse failure. Per-keyword members turn the same mistake into an `AttributeError` at import. The parser will have more keyword match sites than anywhere else in this codebase. Recorded in `_docs/decisions.md`.

**Positions are code points, not bytes.** `blame` rows carry arbitrary source lines, so byte offsets would produce error carets that drift — but only for non-ASCII queries, which is the kind of bug that ships looking fine. QA verified with a 4-byte astral emoji rather than only an accented Latin letter, since two-byte and four-byte characters fail differently under this confusion.

## Verification

QA verdict: PASS on all 23 criteria — https://github.com/ionut-banu/historian/issues/3#issuecomment-5437691980

82 new tests, 274 in the suite. Every lexical question with a SQLite answer was checked against `sqlite3` rather than reasoned about — quote doubling, the three real forms, what an unterminated string does, and that `==` is SQLite-legal and therefore deliberately excluded here rather than overlooked.

The keyword-set test was the one worth scrutinising: a test asserting the enum matches the grammar proves nothing if it builds its expected set from the enum. QA confirmed `V1_KEYWORDS` is a hand-written literal, recounted it against §1, and checked that removing a member from the source turns it red.

Both parties mutation-tested with different mutations. QA's: reordering the operator lookup so one-character tokens win, which turned the maximal-munch count assertions red; breaking the newline column reset, which turned three position tests red; removing a keyword from `KEYWORD_TYPES`.

Differential: n/a, no suite until M3. Fuzzer: n/a, not built until M5.

## Deliberately excluded

Block comments, scientific and hex numeric literals, and `==` as an alias for `=`. All four are real SQLite lexical forms found while checking against `sqlite3`; §1's grammar does not admit them. Filed as #6 against `v2 — Backlog`.