### PR TITLE
Reject NaN in values._rank, the single comparison chokepoint (#15)

### DIFF
--- a/_docs/decisions.md
+++ b/_docs/decisions.md
@@ -187,3 +187,18 @@ The PM is told to file work that contradicts the non-goals as a v2
 issue, but nothing said where those live, so they would have collected
 with no milestone and been invisible. They now go to "v2 - Backlog",
 which holds nothing anyone is scheduled to build.
+
+2026-08-31 - Arithmetic producing NaN yields NULL, enforced in
+exec/expression.py
+
+SQLite has no NaN - typeof(0.0/0.0) is null - confirmed against
+sqlite3. values.py now rejects a NaN that reaches it (issue #15),
+but nothing yet stops arithmetic from producing one in the first
+place: values.py has no arithmetic, so it cannot be the enforcement
+point. exec/expression.py, which does not exist yet (#12, blocked
+on #9), owns converting a NaN result of +, -, *, / into NULL before
+it ever reaches a Value position.
+
+Recorded now, matching the column-affinity precedent, because the
+fuzzer is expected to generate 0.0/0.0-shaped queries early and this
+is a mismatch with no owner until #12 lands.

--- a/src/historian/values.py
+++ b/src/historian/values.py
@@ -40,6 +40,22 @@ Every function here validates its arguments and raises ``TypeError`` on a
 ``Bool3`` position). The cost is one isinstance check per call; the
 alternative is a class of bug that never announces itself.
 
+``float('nan')`` is not a ``Value`` either
+-------------------------------------------
+
+SQLite has no NaN storage class - ``typeof(0.0/0.0)`` is ``NULL``, not a
+NaN - so a NaN reaching this module can never be a value SQLite itself
+produced; it is always a bug upstream (issue #15). Every function routes
+through :func:`_rank`, which raises ``ValueError`` - not ``TypeError`` -
+for a NaN operand: NaN is the *right* Python type (``float``) carrying an
+*invalid value*, a different failure mode from ``bool``/``bytes`` being
+the wrong type outright, so it gets a different exception. This module
+has no arithmetic, so it cannot stop a NaN from being computed in the
+first place; that enforcement point is ``exec/expression.py`` (see
+``_docs/decisions.md``, 2026-08-31). Infinity is unaffected - it is an
+ordinary, legal ``float`` and ``typeof(9e999)`` is ``real`` - only NaN
+fails ``math.isnan``.
+
 Comparison is not ordering
 --------------------------
 
@@ -89,6 +105,8 @@ and ``||`` (all ``exec/expression.py``), and aggregate accumulation (the
 ``Aggregate`` operator).
 """
 
+import math
+
 __all__ = [
     "Bool3",
     "Value",
@@ -125,11 +143,21 @@ _RANK_TEXT = 2
 
 
 def _rank(value: Value) -> int:
-    """The storage-class rank of *value*, validating its type.
+    """The storage-class rank of *value*, validating its type and value.
 
     Raises ``TypeError`` for anything that is not a ``Value`` - including
     ``bool``, which is checked before ``int`` because it is a subclass of
-    it.
+    it. Raises ``ValueError`` for ``float('nan')`` (and ``-nan``): NaN is
+    the right Python type but not a value SQLite can ever produce or
+    store - ``typeof(0.0/0.0)`` is ``null``, not a NaN (see
+    `_docs/decisions.md`) - so it is a wrong *value*, not a wrong *type*,
+    which is why it gets a different exception than ``bool``/``bytes``
+    above. Infinity is an ordinary, legal ``float`` and is not affected;
+    only NaN fails ``math.isnan``.
+
+    This is the single chokepoint every public function in this module
+    routes through, so the guard lives here once rather than being
+    repeated in each of them.
     """
     if value is None:
         return _RANK_NULL
@@ -139,6 +167,13 @@ def _rank(value: Value) -> int:
             f"into a value position (got {value!r})"
         )
     if isinstance(value, (int, float)):
+        if isinstance(value, float) and math.isnan(value):
+            raise ValueError(
+                "NaN is not a SQL Value; SQLite has no NaN storage class "
+                "(typeof(0.0/0.0) is NULL) so one reaching this module is "
+                "always a bug upstream, not a valid value to compare or "
+                "order"
+            )
         return _RANK_NUMERIC
     if isinstance(value, str):
         return _RANK_TEXT

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -69,6 +69,123 @@ def test_comparisons_reject_unsupported_types(func):
         func(b"bytes", 1)
 
 
+# --- NaN: rejected as a value, not silently ordered ----------------------
+#
+# sqlite3 has no NaN storage class - `select 0.0/0.0, typeof(0.0/0.0);`
+# -> (blank)|null - so a NaN reaching this module is never a value SQLite
+# could have produced; it can only be a bug upstream (issue #15). It is
+# rejected in `_rank`, the single chokepoint every public function in this
+# module routes through, with `ValueError` rather than `TypeError`: NaN is
+# the right Python type (`float`) carrying an invalid *value*, which is a
+# different failure mode from `bool`/`bytes` being the wrong *type*
+# entirely. Infinity is a normal `float` and stays legal - see the
+# "NaN does not take infinity down with it" tests below.
+
+NAN = float("nan")
+NEGATIVE_NAN = -float("nan")
+
+
+@pytest.mark.parametrize("func", COMPARISONS)
+@pytest.mark.parametrize("nan", [NAN, NEGATIVE_NAN])
+def test_comparisons_reject_nan_on_either_side_or_both(func, nan):
+    with pytest.raises(ValueError):
+        func(nan, 1.0)
+    with pytest.raises(ValueError):
+        func(1.0, nan)
+    with pytest.raises(ValueError):
+        func(nan, nan)
+
+
+def test_gt_of_nan_and_nan_no_longer_returns_true():
+    """The issue's own reproduction: `gt(float('nan'), float('nan'))`
+    used to return `True` because NaN's numeric rank made it compare
+    equal to itself before the value itself was ever examined."""
+    with pytest.raises(ValueError):
+        gt(NAN, NAN)
+
+
+@pytest.mark.parametrize("func", [is_, is_not])
+@pytest.mark.parametrize("nan", [NAN, NEGATIVE_NAN])
+def test_is_and_is_not_reject_nan(func, nan):
+    with pytest.raises(ValueError):
+        func(nan, nan)
+    with pytest.raises(ValueError):
+        func(nan, 1.0)
+    with pytest.raises(ValueError):
+        func(1.0, nan)
+
+
+@pytest.mark.parametrize("func", [is_null, is_not_null])
+@pytest.mark.parametrize("nan", [NAN, NEGATIVE_NAN])
+def test_is_null_and_is_not_null_reject_nan(func, nan):
+    with pytest.raises(ValueError):
+        func(nan)
+
+
+@pytest.mark.parametrize("nan", [NAN, NEGATIVE_NAN])
+def test_order_key_rejects_nan(nan):
+    with pytest.raises(ValueError):
+        order_key(nan)
+
+
+def test_sorted_by_order_key_raises_on_nan_instead_of_silently_misordering():
+    """The exact reproduction from the issue body: NaN's comparisons are
+    all False, so it used to sort into an arbitrary position rather than
+    raising. `sorted()` propagates whatever `order_key` raises."""
+    with pytest.raises(ValueError):
+        sorted([3.0, NAN, 1.0, 2.0], key=order_key)
+
+
+@pytest.mark.parametrize("func", COMPARISONS)
+def test_null_does_not_mask_nan_on_the_other_side(func):
+    """`_compare` ranks both operands before it looks at NULL, so a NaN
+    paired with a NULL must still raise - not be swallowed into the
+    ordinary NULL-propagation result of `None`."""
+    with pytest.raises(ValueError):
+        func(None, NAN)
+    with pytest.raises(ValueError):
+        func(NAN, None)
+
+
+def test_nan_raises_valueerror_not_typeerror():
+    """Rationale (see the issue #15 grooming comment): NaN is a value of
+    the correct Value type (float) that fails a value-level validity
+    check, which is a different failure mode from the TypeError raised
+    for a wrong-type operand like bool or bytes. Keeping them distinct
+    lets a caller tell the two apart without string-matching messages."""
+    with pytest.raises(ValueError):
+        eq(NAN, 1.0)
+    with pytest.raises(TypeError):
+        eq(True, 1.0)
+
+
+# --- NaN does not take infinity down with it ------------------------------
+
+# sqlite3 :memory: "select 9e999, typeof(9e999), -9e999, typeof(-9e999);"
+#   -> Inf|real|-Inf|real. Infinity is an ordinary, legal REAL in SQLite;
+# only NaN is impossible. A fix that guards against NaN by rejecting any
+# "not a finite float" value would wrongly take infinity down with it.
+
+
+def test_infinity_is_unaffected_by_the_nan_guard():
+    # Same rank as any other numeric, payload untouched.
+    assert order_key(float("inf")) == (order_key(1.0)[0], float("inf"))
+    assert order_key(float("-inf")) == (order_key(1.0)[0], float("-inf"))
+    assert gt(float("inf"), 5) is True
+    assert lt(float("-inf"), -1000000) is True
+    assert eq(float("inf"), float("inf")) is True
+
+
+def test_infinity_sorts_at_the_ends_via_order_key():
+    column = [3.0, float("inf"), 1.0, float("-inf")]
+    assert sorted(column, key=order_key) == [
+        float("-inf"),
+        1.0,
+        3.0,
+        float("inf"),
+    ]
+
+
 @pytest.mark.parametrize("func", [and3, or3])
 @pytest.mark.parametrize("bad", [1, 0, "x", 1.0])
 def test_connectives_reject_non_bool3(func, bad):


### PR DESCRIPTION
Closes #15.

## What was wrong

`values.py` validated the *types* of the values it compared but not their *values*, so a NaN passed straight through `_rank` — the same guard that correctly rejects `bool` and `bytes` — and every ordering guarantee in the module quietly stopped holding:

```
gt(nan, nan)                                 -> True
_compare(nan, 1) -> 1  and  _compare(1, nan) -> 1      # antisymmetry gone
sorted([3.0, nan, 1.0, 2.0], key=order_key)  -> [3.0, nan, 1.0, 2.0]
```

That last line is the one that matters. `order_key` is the total order every future `Sort` operator rests on, and it returned the list unsorted rather than raising. No exception, no warning — just wrong rows, in the module spec §6 calls "the one to slow down on" because everything else inherits it.

SQLite has no NaN storage class at all: `typeof(0.0/0.0)` is `null`. So a NaN arriving here can never be a value SQLite itself produced, and is always a bug upstream.

## What changed

One `math.isnan` guard in `_rank`, raising `ValueError`.

**Why `_rank` and not the six comparison functions.** Every public function in the module already routes through `_rank`, so the guard lives there once. Scattering it across the comparison functions would satisfy every acceptance criterion today and still miss the next function added to the module.

**Why `ValueError` rather than `TypeError`.** `_rank` already raises `TypeError` for `bool` and `bytes`, which are the wrong *type*. NaN is the right type — it really is a `float` — carrying a value that cannot exist in SQLite. Different failure mode, different exception. This was an open ambiguity in the filed issue and was settled deliberately during grooming so that the engineer and QA could not land on incompatible answers.

**Infinity is untouched and stays legal.** `sqlite3 :memory: "select 9e999, typeof(9e999)"` is `Inf|real`, so infinity is an ordinary value and only NaN fails `math.isnan`. There are explicit tests pinning this, because a fix that took infinity down with NaN would pass a careless reading of the issue.

## Deliberately deferred

**Arithmetic that produces a NaN is not stopped by this PR**, and cannot be: `values.py` has no arithmetic. `0.0/0.0` must yield `NULL`, and the only place that can be enforced is `exec/expression.py`, which does not exist yet — it arrives with #12, itself blocked on #9.

Rather than let #15 inherit that blocker or drop the rule on the floor, the rule and its future owner are recorded in `_docs/decisions.md` now, while the investigation context is fresh. That follows the precedent set by the 2026-08-27 column-affinity entry, which was written the same way and for the same reason: a mismatch with no owner is one the fuzzer finds much later, when nobody remembers why.

One consequence worth flagging for a reviewer: spec §3 currently says a NaN reaching `order_key` "is a risk for the expression evaluator rather than for this module." That sentence goes slightly stale with this merge, since `values.py` now refuses NaN defensively too. It is not a contradiction — the *real* fix still lives in the evaluator — so no spec edit is included here, and #12 is the natural place to revisit the wording.

## Verification

**QA verdict: PASS** — https://github.com/ionut-banu/historian/issues/15#issuecomment-5484425428

`uv run pytest` gives **307 passed**, against a baseline of 274 on `main`. The 33 new tests were written before the fix and confirmed failing for the right reason (`DID NOT RAISE ValueError`) first, per the TDD rule in `_docs/process.md`.

`git diff main..issue-15-nan-guard -- tests/` contains **no removed lines** — the change to the suite is purely additive, so nothing was weakened to make this pass.

Verified independently of the test suite, by driving the module directly rather than by reading the diff:

| probe | result |
|---|---|
| `gt(nan, nan)` | `ValueError` |
| `eq(None, nan)` — a NULL must not mask a NaN | `ValueError` |
| `sorted([3.0, nan, 1.0, 2.0], key=order_key)` | `ValueError` |
| `gt(inf - inf, 1)` — arithmetic-produced NaN | `ValueError` |
| `order_key(inf)`, `gt(inf, 1)` — must stay legal | `(1, inf)`, `True` |
| `gt(True, 1)` — must stay `TypeError`, not `ValueError` | `TypeError` |

The 2026-08-27 exactness decision is intact: `eq(9007199254740993, 9007199254740992.0)` is still `False` and `gt` of the same is still `True`, and there is no `float()` conversion anywhere on the comparison path.

## Provenance

Filed by the M1 milestone review, which ran over the whole milestone diff after #3 closed. It was the most serious of the four substantive findings — the only one that produces silently wrong results rather than an error or a stale document.
