### PR TITLE
Lexer: non-ASCII characters start identifiers, not Python's isalpha (#16)

### DIFF
--- a/_docs/decisions.md
+++ b/_docs/decisions.md
@@ -202,3 +202,46 @@ it ever reaches a Value position.
 Recorded now, matching the column-affinity precedent, because the
 fuzzer is expected to generate 0.0/0.0-shaped queries early and this
 is a mismatch with no owner until #12 lands.
+
+2026-09-01 - Any non-ASCII character can start or continue an
+identifier; the lexer never asks if it is a letter
+
+Issue #16 started as a narrower bug: `_read_number` used
+`str.isdigit()`, which is `True` for non-ASCII digit-shaped
+characters like `²` and Arabic-Indic `١٢٣`, so those could reach
+`int()`/`float()` and raise. The obvious fix - restrict the digit
+paths to ASCII and leave `_read_identifier` on Python's
+`isalpha`/`isalnum` - turned out to be wrong, not just incomplete.
+Confirmed against `sqlite3` 3.51.0: `select ™;` and `select café;`
+both fail with `no such column`, so SQLite lexed both as
+identifiers. But `'™'.isalpha()` and `'™'.isalnum()` are both
+`False` in Python, so the "obvious fix" still raises `LexError` on
+`™`, on `‽`, and on any other non-ASCII symbol Python does not
+classify as a letter or digit.
+
+SQLite's real rule has no such gap: an ASCII digit (`0`-`9`) can
+start a number, and literally every other non-quote, non-operator
+character - including every character above ASCII - can start an
+identifier. It never consults a Unicode property table. Decided to
+match this exactly rather than approximate it with Python's
+classifiers, so `_read_identifier` now accepts any character for
+which `not char.isascii()`, full stop, with no `isalpha`/`isalnum`
+call in the non-ASCII path at all.
+
+The cost is real: this makes `²`, `™`, and other symbol characters
+lex as identifiers, which reads as nonsense to a human. It is
+still the better rule, for three reasons. It is simpler than
+asking Python's Unicode database anything, and simpler still in
+Rust, where the equivalent is one `is_ascii()` check rather than a
+Unicode-aware classifier. It ports directly - the same plain
+codepoint comparisons work unchanged. And it means `²`, `café`,
+and `™` all fail the same way SQLite fails them: `no such column`
+once `sql/binder.py` exists (#9), not merely "some error" from the
+lexer today. Per this module's own docstring, an identifier that
+resolves to nothing is the binder's error to raise, not the
+lexer's - and a symbol character is exactly that case, not a
+lexing failure.
+
+Also decided in the same pass: `\f` (form feed) joins `\t`/`\r` as
+whitespace, confirmed against SQLite; `\v` (vertical tab) does
+not, because SQLite rejects it too.

--- a/src/historian/sql/lexer.py
+++ b/src/historian/sql/lexer.py
@@ -255,7 +255,49 @@ def tokenize(source: str) -> list[Token]:
     return _Lexer(source).run()
 
 
-_WHITESPACE = " \t\r"
+#: `\f` (form feed) is whitespace to SQLite; `\v` (vertical tab) is not and
+#: must stay out of this set - see _docs/decisions.md, 2026-09-01.
+_WHITESPACE = " \t\r\f"
+
+
+def _is_ascii_digit(char: str) -> bool:
+    """Is *char* one of `0`-`9`? Plain codepoint comparison, not
+    `str.isdigit()` - that also accepts non-ASCII digit-shaped characters
+    (superscripts, Arabic-Indic digits, ...) that SQLite does not treat as
+    numeric. See _docs/decisions.md, 2026-09-01."""
+    return "0" <= char <= "9"
+
+
+def _is_ascii_letter(char: str) -> bool:
+    """Is *char* one of `a`-`z` or `A`-`Z`? Plain codepoint comparison,
+    matching `_is_ascii_digit`."""
+    return ("a" <= char <= "z") or ("A" <= char <= "Z")
+
+
+def _is_identifier_start(char: str) -> bool:
+    """Can *char* start an identifier?
+
+    SQLite's rule (confirmed against `sqlite3` 3.51.0), not Python's: an
+    ASCII letter, an underscore, or any character at all above ASCII -
+    SQLite never asks whether a codepoint is alphabetic, so neither does
+    this. `²`, `™` and `café`'s `é` all qualify; only an ASCII digit,
+    a quote, or an operator/punctuation character does not. See
+    _docs/decisions.md, 2026-09-01.
+    """
+    if char == "":
+        return False
+    return _is_ascii_letter(char) or char == "_" or not char.isascii()
+
+
+def _is_identifier_char(char: str) -> bool:
+    """Can *char* continue an identifier already started?
+
+    Everything `_is_identifier_start` accepts, plus ASCII digits - `foo1`
+    is a valid identifier even though a digit cannot start one.
+    """
+    if char == "":
+        return False
+    return _is_identifier_start(char) or _is_ascii_digit(char)
 
 
 class _Lexer:
@@ -329,11 +371,11 @@ class _Lexer:
             return self._read_string(start)
         if char == '"':
             return self._read_quoted_identifier(start)
-        if char.isdigit():
+        if _is_ascii_digit(char):
             return self._read_number(start)
-        if char == "." and self._peek(1).isdigit():
+        if char == "." and _is_ascii_digit(self._peek(1)):
             return self._read_number(start)
-        if char.isalpha() or char == "_":
+        if _is_identifier_start(char):
             return self._read_identifier(start)
 
         return self._read_operator(start)
@@ -385,12 +427,12 @@ class _Lexer:
     def _read_number(self, start: Position) -> Token:
         chars: list[str] = []
         is_real = False
-        while self._peek().isdigit():
+        while _is_ascii_digit(self._peek()):
             chars.append(self._advance())
         if self._peek() == ".":
             is_real = True
             chars.append(self._advance())
-            while self._peek().isdigit():
+            while _is_ascii_digit(self._peek()):
                 chars.append(self._advance())
         token_type = TokenType.REAL if is_real else TokenType.INTEGER
         return Token(token_type, "".join(chars), start)
@@ -399,7 +441,7 @@ class _Lexer:
 
     def _read_identifier(self, start: Position) -> Token:
         chars: list[str] = []
-        while self._peek().isalnum() or self._peek() == "_":
+        while _is_identifier_char(self._peek()):
             chars.append(self._advance())
         text = "".join(chars)
         keyword_type = _KEYWORDS_BY_TEXT.get(text.upper())
@@ -447,8 +489,10 @@ class _Lexer:
             return Token(token_type, char, start)
 
         # `!` not followed by `=` (handled above as `NE`) starts no valid
-        # v1 token, the same as any other unrecognised character.
-        self._advance()
+        # v1 token, the same as any other unrecognised character. No
+        # `_advance()` here: `start` was captured before this character
+        # was consumed, so advancing past it first has no observable
+        # effect on the error we raise.
         raise LexError(
             f"unexpected character {char!r} at line {start.line}, "
             f"column {start.column}",

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -102,6 +102,107 @@ def test_identifier_that_is_not_a_keyword_lexes_as_identifier():
     assert tokens[0].text == "count"
 
 
+def test_leading_underscore_identifier():
+    tokens = tokenize("_foo")
+    assert tokens[0].type is TokenType.IDENTIFIER
+    assert tokens[0].text == "_foo"
+
+
+@pytest.mark.parametrize(
+    "source,keyword_type",
+    [("SELECTED", TokenType.SELECT), ("ANDy", TokenType.AND)],
+)
+def test_keyword_spelling_as_prefix_of_longer_identifier_is_one_token(
+    source, keyword_type
+):
+    """A keyword's spelling occurring as a strict prefix of a longer
+    identifier must not split into the keyword token followed by
+    whatever remains - the identifier scan has to consume the whole
+    run of identifier characters before checking the keyword table."""
+    tokens = tokenize(source)
+    assert _types(tokens) == [TokenType.IDENTIFIER, TokenType.EOF]
+    assert tokens[0].type is not keyword_type
+    assert tokens[0].text == source
+
+
+# --- Non-ASCII identifiers (issue #16) ------------------------------------
+#
+# SQLite's tokenizer rule, confirmed against sqlite3 3.51.0: an ASCII digit
+# starts a number, and every other non-quote, non-operator character -
+# including every character above ASCII - starts an identifier. It never
+# asks whether a codepoint is alphabetic. Python's str.isalpha()/isdigit()
+# do not partition non-ASCII characters this way (superscript '²' and
+# Arabic-Indic digits are "digits" to Python; '™' is neither a letter nor
+# a digit to Python), so the lexer must not consult them for anything
+# above ASCII. See _docs/decisions.md, 2026-09-01.
+
+
+def test_non_ascii_letters_lex_as_identifier():
+    # sqlite3: select café; select 中;  -> both "no such column", i.e.
+    # both lex as identifiers, not lexer errors.
+    for source in ("café", "中"):
+        tokens = tokenize(source)
+        assert _types(tokens) == [TokenType.IDENTIFIER, TokenType.EOF]
+        assert tokens[0].text == source
+
+
+def test_superscript_digit_lexes_as_identifier_not_integer():
+    # sqlite3: select ²;  -> "no such column: ²", not a parse/numeric
+    # error, so SQLite lexed it as an identifier. Python's '²'.isdigit()
+    # is True and '²'.isalpha() is False, so this is the case that
+    # catches a fix that only widens the digit path to ASCII while
+    # leaving the identifier path on Python's character classifiers.
+    tokens = tokenize("²")
+    assert _types(tokens) == [TokenType.IDENTIFIER, TokenType.EOF]
+    assert tokens[0].text == "²"
+
+
+def test_arabic_indic_digits_lex_as_single_identifier_not_integer():
+    # sqlite3: select ١٢٣;  -> "no such column: ١٢٣". Each of these three
+    # codepoints is individually str.isdigit() == True in Python, so a
+    # lexer that treats "isdigit" as "can start/continue a number" would
+    # produce a bogus INTEGER (or crash decoding it as one) instead.
+    tokens = tokenize("١٢٣")
+    assert _types(tokens) == [TokenType.IDENTIFIER, TokenType.EOF]
+    assert tokens[0].text == "١٢٣"
+
+
+def test_trademark_sign_lexes_as_identifier():
+    # sqlite3: select ™;  -> "no such column: ™". '™'.isalpha() and
+    # '™'.isalnum() are both False in Python, so this is the character
+    # that catches an incomplete fix: one that widens _read_identifier's
+    # digit handling but still gates on Python's isalpha/isalnum still
+    # raises LexError here. The only rule that gets this right is "any
+    # non-ASCII character can be part of an identifier," full stop.
+    tokens = tokenize("™")
+    assert _types(tokens) == [TokenType.IDENTIFIER, TokenType.EOF]
+    assert tokens[0].text == "™"
+
+
+@pytest.mark.parametrize(
+    "char",
+    [
+        "Ω",  # Greek capital letter (Lu) - already worked, must keep working
+        "é",  # Latin small letter with diacritic (Ll)
+        "中",  # CJK ideograph (Lo)
+        "²",  # superscript two (No) - digit-shaped, not alphabetic
+        "١",  # Arabic-Indic digit one (Nd) - isdigit() is True in Python
+        "™",  # trademark sign (So) - neither alpha nor digit in Python
+        "§",  # section sign (Po)
+        "‽",  # interrobang (Po)
+        "́",  # combining acute accent (Mn), alone
+        "😀",  # emoji (So), outside the Basic Multilingual Plane
+    ],
+)
+def test_non_ascii_characters_across_categories_always_lex_as_identifier(char):
+    """General check behind the named examples above: whatever Unicode
+    category a non-ASCII character falls in, it starts (and here, is the
+    whole of) an identifier - never a LexError, never INTEGER or REAL."""
+    tokens = tokenize(char)
+    assert _types(tokens) == [TokenType.IDENTIFIER, TokenType.EOF]
+    assert tokens[0].text == char
+
+
 def test_double_quoted_identifier_strips_quotes():
     tokens = tokenize('"path"')
     assert tokens[0].type is TokenType.IDENTIFIER
@@ -297,6 +398,47 @@ def test_block_comment_is_not_supported_in_v1():
     ]
 
 
+# --- Whitespace (issue #16) ----------------------------------------------
+
+
+def test_form_feed_is_skipped_like_other_whitespace():
+    tokens = tokenize("SELECT\f1")
+    assert _types(tokens) == [TokenType.SELECT, TokenType.INTEGER, TokenType.EOF]
+    assert tokens[1].text == "1"
+
+
+def test_form_feed_separates_arbitrary_tokens():
+    """Not just after a keyword: a separator between any two tokens."""
+    tokens = tokenize("a\fFROM\fb")
+    assert _types(tokens) == [
+        TokenType.IDENTIFIER,
+        TokenType.FROM,
+        TokenType.IDENTIFIER,
+        TokenType.EOF,
+    ]
+    assert tokens[0].text == "a"
+    assert tokens[2].text == "b"
+
+
+def test_form_feed_advances_column_not_line():
+    # Same convention as test_carriage_return_and_tab_advance_column_not_line:
+    # a single non-newline whitespace character advances the column by one.
+    source = "a\fb"
+    tokens = tokenize(source)
+    b_token = tokens[1]
+    assert b_token.position.line == 1
+    assert b_token.position.column == 3
+
+
+def test_form_feed_inside_string_literal_is_preserved():
+    """Whitespace-skipping must never reach inside a string literal - a
+    form feed between the quotes is data, not a separator."""
+    tokens = tokenize("'a\fb'")
+    assert tokens[0].type is TokenType.STRING
+    assert tokens[0].text == "a\fb"
+    assert len(tokens[0].text) == 3
+
+
 # --- Illegal characters -------------------------------------------------
 
 
@@ -316,6 +458,14 @@ def test_various_unrecognised_characters_raise(char):
 def test_bang_not_followed_by_equals_raises():
     with pytest.raises(LexError):
         tokenize("!")
+
+
+def test_vertical_tab_still_raises_lex_error():
+    """Unlike form feed, vertical tab is not whitespace to SQLite either
+    (confirmed: sqlite3 rejects it) - it must stay rejected here, not be
+    added alongside \\f."""
+    with pytest.raises(LexError):
+        tokenize("SELECT\v1")
 
 
 # --- Positions -----------------------------------------------------------


### PR DESCRIPTION
Closes #16.

## What was wrong

The lexer asked Python what a digit and a letter are. SQLite asks neither.

`_read_number` dispatched on `str.isdigit()`, which is Unicode-aware, so characters that merely look numeric became `INTEGER` tokens:

```
tokenize("١٢٣")  ->  INTEGER("١٢٣")     # int() would give 123
tokenize("²")    ->  INTEGER("²")       # int() raises ValueError outright
```

SQLite lexes both as identifiers and fails at name resolution (`no such column: ١٢٣`), so historian accepted a query SQLite rejects, and `²` was on a direct path to a traceback — which spec §5 forbids. Separately, `_WHITESPACE` omitted `\f`, which SQLite treats as whitespace, so `SELECT\f1` was a `LexError` here and `1` there.

## The fix is not the one the issue proposed

The filed issue suggested restricting the digit paths to ASCII and leaving `_read_identifier` on `isalpha`/`isalnum`. **That is wrong, not merely incomplete**, and grooming caught it.

Python's classifiers do not partition the non-ASCII range. `™` is the counterexample:

```
'™'.isalpha()  -> False
'™'.isalnum()  -> False
'™'.isdigit()  -> False

$ sqlite3 :memory: "select ™;"
Error: in prepare, no such column: ™      # SQLite lexed it as an identifier
```

So a classifier-based fix passes `²` and still raises `LexError` on `™`, `§`, `€`, and every other non-ASCII symbol Python declines to call a letter.

SQLite's actual rule has no such gap: **an ASCII digit starts a number; every other non-quote, non-operator character — including everything above ASCII — starts an identifier.** It never consults a Unicode property table. This PR implements that rule directly, in four small pure helpers built on plain codepoint comparisons (`"0" <= char <= "9"`, `not char.isascii()`).

That single change fixes the digit bug and the `™` gap together — they are not two patches. It also closes the `int()` traceback risk by construction rather than by a downstream guard: no character can now produce token text that is not valid decimal digits.

`AGENTS.md` asks for code that ports to Rust by translation rather than redesign, and this direction helps rather than costs — the Rust equivalent is `is_ascii()`, not a Unicode-aware classifier.

Also: `\f` joins the whitespace set. **`\v` deliberately does not** — SQLite rejects vertical tab too, and there is a test pinning that it stays rejected.

## Deliberately not fixed

Two lexer gaps are visible from this change and are **not** touched, with tests pinning that they stay as they are:

- `tokenize("1e10")` still yields `INTEGER("1"), IDENTIFIER("e10")`. Scientific notation belongs to the v2 issue #6.
- `tokenize("3abc")` still yields two tokens where SQLite reports `unrecognized token`. Filed as **#22** — it is pre-existing, unrelated to Unicode, and the worse of the two: once the parser exists, `SELECT 3abc` will likely read as `SELECT 3 AS abc` and return a row where SQLite errors. Folding it in here would have made this issue's criteria much harder to reason about.

## Verification

**QA verdict: PASS** — https://github.com/ionut-banu/historian/issues/16#issuecomment-5485903629

`uv run pytest` gives **329 passed**, against 307 on `main`. 22 new tests, written first; `git diff main..issue-16-lexer-charclass -- tests/` has **no removed lines**, so nothing was weakened to make this pass.

QA and the orchestrator verified independently and agree. The result is stronger than the criteria required — they only asked that historian not accept what SQLite rejects, but what landed is matching *error classes* across the whole probe set:

| input | historian | sqlite3 |
|---|---|---|
| `™` `😀` `µ` `Ⅻ` `½` `²` `١٢٣` `café` `中` | `IDENTIFIER` | `no such column` |
| `_` | `IDENTIFIER` | `no such column` |
| `$` `#` `@` `` ` `` `:` `^` | `LexError` | `unrecognized token` |
| `/` | `SLASH` | `near "/": syntax error` |

Zero disagreements across emoji, combining marks, zero-width and bidi controls, Roman numerals, fractions, and the ASCII boundary. That is what makes M3's differential harness straightforward here rather than a pile of special cases.

Also confirmed: `tokenize("'a\fb'")` is a single `STRING` of three characters, so whitespace-skipping does not reach inside a literal.

## Provenance

Filed by the M1 milestone review. The review's diagnosis was right and its prescription was wrong, which the PM caught during grooming by testing `™` rather than accepting the suggested fix — the reason `_docs/process.md` puts a grooming step between a filed issue and an engineer.
