### PR TITLE
AST and recursive-descent parser for SELECT / FROM / WHERE (#8, #17)

### DIFF
--- a/_docs/decisions.md
+++ b/_docs/decisions.md
@@ -245,3 +245,52 @@ lexing failure.
 Also decided in the same pass: `\f` (form feed) joins `\t`/`\r` as
 whitespace, confirmed against SQLite; `\v` (vertical tab) does
 not, because SQLite rejects it too.
+
+2026-09-01 - An INTEGER literal past int64 max becomes a float,
+enforced in sql/parser.py
+
+Issue #17: SQLite's integers are int64
+(-9223372036854775808..9223372036854775807). Confirmed against
+sqlite3 3.51.0:
+
+    select 9223372036854775807, typeof(9223372036854775807);
+    9223372036854775807|integer
+    select 9223372036854775808, typeof(9223372036854775808);
+    9.22337203685478e+18|real
+    select 9223372036854775808 = 9223372036854775809;
+    1
+
+A decimal literal that overflows becomes a REAL, and every literal
+past the boundary that rounds to the same double compares equal to
+every other one that does. Python's int() never overflows, so
+without an explicit check historian would keep such literals
+distinct and disagree with SQLite. sql/parser.py's literal
+construction now parses an INTEGER token's digit text with int();
+if the result exceeds 9223372036854775807, it constructs float()
+from the same text instead. The lexer never emits a signed INTEGER
+token - a leading `-` is always its own MINUS token - so the rule
+is one-directional and there is no negative bound to check here.
+
+This is unrelated to the 2026-08-27 "numeric comparison is exact;
+no float() anywhere" decision, and the two must not be conflated.
+That decision governs comparison in values.py, which stays exact
+and is pinned by a test at the 2^53 case - nothing here adds a
+float() call there. What is decided here is literal construction
+in sql/parser.py, which happens before any value ever reaches
+values.py.
+
+Not implemented: SQLite special-cases a unary minus written
+directly against the int64-min literal, so
+typeof(-9223372036854775808) is integer even though the unsigned
+digit sequence alone (9223372036854775808) overflows to REAL.
+Checked whether Part A's grammar can observe the gap between that
+and the naive path (negate an overflowed float) - it cannot: 2^63
+is exactly representable as a double, so -9223372036854775808.0
+compares exactly equal to the true int -9223372036854775808 under
+Python's (and SQLite's) exact int/float comparison, and this
+grammar has no typeof() and no arithmetic to tell them apart by.
+They diverge only once arithmetic exists (-9223372036854775808 + 1
+would round incorrectly starting from the float), which has no
+home until exec/expression.py (#12). Recorded now, matching the
+NaN-yields-NULL precedent above, so whoever builds arithmetic knows
+to revisit it rather than rediscover it.

--- a/_docs/decisions.md
+++ b/_docs/decisions.md
@@ -294,3 +294,88 @@ would round incorrectly starting from the float), which has no
 home until exec/expression.py (#12). Recorded now, matching the
 NaN-yields-NULL precedent above, so whoever builds arithmetic knows
 to revisit it rather than rediscover it.
+
+2026-09-01 - Deeply nested expressions raise ParseError, not
+RecursionError; two limits, not one
+
+Issue #8 round 1 (QA FAIL): `SELECT` + 89 `(` + `1` + 89 `)` +
+`FROM blame` parsed; 90 raised a raw, unhandled RecursionError -
+the exact traceback spec §5 forbids. Root cause: `_parse_expr`
+descends through nine more precedence methods to `_parse_primary`,
+which recurses into `_parse_expr` again for a parenthesised
+group's contents, so one level of `(...)` nesting costs several
+Python stack frames, not one.
+
+Measured before changing anything, with `sys.getrecursionlimit()`
+at its default of 1000. Frames consumed per level of nesting, by
+instrumenting `_parse_primary` and reading the call-stack depth at
+each visit: bare parens 12, function-call arguments 15, IN-list
+values 6, a NOT chain 1, a unary +/- chain 1. These numbers explain
+the observed crash points exactly (1000 / 12 = 89.9, matching the
+89-parses/90-crashes boundary) and are not expected to be stable
+across Python versions or builds - the fix does not depend on
+their staying exact, only on having measured rather than guessed
+them.
+
+`sqlite3 3.51.0` accepts 90 levels of bare parens and returns 1
+(AGENTS.md: "where historian and SQLite disagree, SQLite is
+right"), so a depth limit below 90 would itself be a new
+disagreement, not a fix. Checked what SQLite itself does at
+depth, by binary search against a live sqlite3 process:
+
+    bare parens:            93 ok, 94 fails
+    nested function calls:  31 ok, 32 fails
+    nested IN-lists:        31 ok, 32 fails
+
+All three fail the same way: "Error: in prepare, parser stack
+overflow" - SQLite's own LALR parser stack, not its documented
+`SQLITE_MAX_EXPR_DEPTH` (confirmed present at its default of 1000
+via `PRAGMA compile_options`, but never reached for any of these
+three shapes on this build).
+
+Two consequences. First, `sys.setrecursionlimit` is not a fix -
+it relocates the cliff and risks a hard interpreter crash in place
+of a catchable exception. Second, catching RecursionError and
+re-raising as ParseError is a patch on the symptom: the real limit
+would still be however much stack Python's own machinery happened
+to have left, which depends on where `parse()` was called from -
+breaking the determinism AGENTS.md requires ("the same repository
+and the same query always produce the same rows"). The fix has to
+count depth explicitly and check it before recursing, the way
+SQLite counts `SQLITE_MAX_EXPR_DEPTH` rather than relying on its
+own C call stack.
+
+A single counter does not work in either direction. A run of `(`,
+`NOT`, or unary `+`/`-` is pure repetition with no semantic content
+of its own - `(((x)))` is exactly `x` - so `sql/parser.py` now
+parses each such run with an explicit loop instead of recursing
+once per token: `_parse_primary`, `_parse_not`, and `_parse_unary`.
+A loop costs one iteration per token, not one Python stack frame,
+so these three forms are bounded by a generous limit,
+`_MAX_NESTING_DEPTH = 1000`, matching SQLite's own documented
+default rather than its build-specific parser-stack quirk - this
+is the number the issue's guidance pointed at directly, and it
+clears all three measured SQLite boundaries above with large
+margin.
+
+Genuine recursion remains where a *new* sub-expression is parsed
+from within another one: a parenthesised group's contents, a value
+inside an `IN (...)` list, or a function-call argument. These
+still go through `_parse_expr` calling itself and really do cost
+Python stack frames, so they are bounded separately by
+`_MAX_RECURSION_DEPTH = 50`, sized from the measured 15
+frames/level worst case (function-call arguments) with several
+times the margin measured as already used before `parse()` is even
+called (31 frames, observed under pytest) - and still clears
+SQLite's own 31-level boundary for these two forms. Collapsing
+this to one limit does not work: low enough to be safe for genuine
+recursion is too low to accept plain deeply-parenthesised input
+SQLite itself accepts, and high enough to match SQLite's declared
+1000 would let genuine recursion exhaust Python's real call stack
+before the counter ever fires.
+
+Not a rewrite of the precedence-climbing structure that passed QA
+in round 1 - only these four call sites change, and `(expr)`
+continues to produce no AST node of its own, so the loop-based
+paren handling is behaviourally identical to the recursive version
+it replaces.

--- a/src/historian/sql/ast.py
+++ b/src/historian/sql/ast.py
@@ -1,0 +1,344 @@
+"""The SQL abstract syntax tree: statement nodes and expression nodes.
+
+The second stage of the pipeline in `_docs/spec.md` §3 (`sql/parser.py`
+is the third - `parser.py` builds these, `ast.py` only defines their
+shape). Two separate hierarchies, per §3's "AST" - a `SelectStatement`
+is not an expression, and code that walks expressions never has to
+consider it.
+
+Every node is a frozen dataclass (`dataclasses.FrozenInstanceError` on
+mutation) and every node carries a `position` - the `Position` of the
+first token that forms it, so an error found later (the binder, the
+evaluator) can point at the offending text without re-deriving where it
+came from. For a node built by combining smaller ones (`BinaryOp`,
+`And`, ...) that is the position of its leftmost operand, i.e. of the
+whole (sub)expression's first token - not the operator's own position.
+
+Schema-blind by design
+-----------------------
+
+Nothing here knows what tables or columns exist. `ColumnRef` carries an
+unresolved `table`/`name` pair and `SelectStatement.from_table` is a
+bare string; neither is checked against a catalog. That is
+`sql/binder.py`'s job (issue #9), which has the `Schema` this module
+deliberately never imports.
+
+What v1's grammar does not need yet
+------------------------------------
+
+`DISTINCT`, `GROUP BY`, `HAVING`, `ORDER BY`, `LIMIT`, `OFFSET` and any
+`JOIN` have no node here - see issue #8's grooming. Adding a field to a
+frozen dataclass later is additive, not a rewrite, so there is nothing
+to pre-declare. `CASE` is deferred the same way, for a different
+reason: it is an independent keyword-delimited primary expression form
+that does not interact with precedence, so building it earlier than it
+is needed would buy nothing.
+
+`IS NULL` / `IS NOT NULL` are not their own node types
+--------------------------------------------------------
+
+`x IS NULL` is `x IS <the NULL literal>` - SQLite's own grammar treats
+`NULL` as an ordinary expression in `IS`'s right-hand operand position,
+not a distinct production. `Is` represents `IS`, `IS NOT`, `IS NULL`
+and `IS NOT NULL` uniformly: the parser builds `IS NULL` as
+`Is(left, Literal(None, ...), negated=False, ...)`. This costs nothing
+extra in the grammar and means the future evaluator calls
+`values.is_`/`values.is_not` directly with no special-casing for the
+NULL spelling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+from historian.sql.lexer import Position
+from historian.values import Value
+
+__all__ = [
+    "And",
+    "Between",
+    "BinaryOp",
+    "ColumnRef",
+    "Expr",
+    "FunctionCall",
+    "In",
+    "Is",
+    "Like",
+    "Literal",
+    "Not",
+    "Operator",
+    "Or",
+    "SelectItem",
+    "SelectStatement",
+    "Star",
+    "Stmt",
+    "UnaryOp",
+    "UnaryOperator",
+]
+
+
+# --- The two hierarchies --------------------------------------------------
+#
+# Plain marker base classes, not dataclasses themselves - each concrete
+# node declares its own fields (including its own `position`) rather than
+# inheriting them, so a node's field order reads naturally at the call
+# site (`Literal(value, position)`, not `Literal(position, value)`).
+# Nothing here uses a metaclass or dynamic dispatch: `isinstance` against
+# these two classes is the only thing they are for.
+
+
+class Expr:
+    """Base of the expression-node hierarchy."""
+
+
+class Stmt:
+    """Base of the statement-node hierarchy. Kept separate from `Expr`
+    per `_docs/spec.md` §3: a `SelectStatement` is not an expression."""
+
+
+# --- Operators -------------------------------------------------------------
+#
+# One `Operator`/`UnaryOperator` member per operator, the same shape as
+# the lexer's "one `TokenType` per keyword" (`_docs/decisions.md`,
+# 2026-08-27) applied to the AST: a typo in a match site is an
+# `AttributeError` at import, not a silently-never-matching string.
+# `UnaryOperator` is a separate enum from `Operator` rather than reusing
+# `ADD`/`SUB` for the unary case - a `UnaryOp` built with `Operator.MUL`
+# would be nonsense, and a distinct enum makes it a type error rather
+# than a runtime surprise.
+
+
+class Operator(Enum):
+    """A binary operator: arithmetic, string concatenation, or
+    comparison. One `BinaryOp` node type covers all of these - they
+    share the same two-operand shape, and SQLite's own precedence table
+    (issue #8's grooming) treats them as one family of binary operators
+    at four different precedence tiers, not four different grammars."""
+
+    ADD = auto()  # +
+    SUB = auto()  # -
+    MUL = auto()  # *
+    DIV = auto()  # /
+    CONCAT = auto()  # ||
+    EQ = auto()  # =
+    NE = auto()  # <> or !=
+    LT = auto()  # <
+    LE = auto()  # <=
+    GT = auto()  # >
+    GE = auto()  # >=
+
+
+class UnaryOperator(Enum):
+    """A prefix unary operator: `+x` or `-x`."""
+
+    POS = auto()  # +x
+    NEG = auto()  # -x
+
+
+# --- Expression nodes --------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Literal(Expr):
+    """A constant value: a number, a string, or `NULL`.
+
+    `value` is a `historian.values.Value` - already the Python type
+    (`int`, `float`, `str`, or `None`) that the rest of the engine
+    consumes, not the token's raw text. See `_read_int_literal` in
+    `parser.py` for the `INTEGER` overflow-to-`float` rule
+    (`_docs/decisions.md`, 2026-09-01).
+    """
+
+    value: Value
+    position: Position
+
+
+@dataclass(frozen=True)
+class ColumnRef(Expr):
+    """A column reference, bare (`path`) or table-qualified
+    (`blame.path`). `table` is `None` for a bare reference - kept as a
+    separate field rather than folded into `name`, so the binder can
+    resolve a qualified reference against a specific table without
+    re-splitting a string."""
+
+    table: str | None
+    name: str
+    position: Position
+
+
+@dataclass(frozen=True)
+class Star(Expr):
+    """`*` or `table.*` in a select list, or as a bare argument to a
+    function call (`count(*)`). Deliberately not a `ColumnRef`: `*`
+    names no single column, and giving it one would make every
+    `ColumnRef` consumer special-case a fake name meaning "all of
+    them" instead of checking a distinct type."""
+
+    table: str | None
+    position: Position
+
+
+@dataclass(frozen=True)
+class FunctionCall(Expr):
+    """`name(args, ...)` - `count(*)`, `sum(x)`, `foo(a, b)`.
+
+    Unevaluated: nothing here knows whether `name` is a real aggregate,
+    a real scalar function, or a typo. That is a binder/executor
+    concern once a registry of built-ins exists (`_docs/spec.md` §3),
+    not a parser one - `foo(x)` is syntactically identical whether
+    `foo` is `count` or an invented name.
+    """
+
+    name: str
+    args: tuple[Expr, ...]
+    position: Position
+
+
+@dataclass(frozen=True)
+class UnaryOp(Expr):
+    """A prefix unary `+` or `-` applied to `operand`.
+
+    Never folded into a negative `Literal`, even when `operand` is
+    itself a numeric literal (`-5` is `UnaryOp(NEG, Literal(5, ...))`,
+    not `Literal(-5, ...)`). Constant folding is a v2 optimisation, and
+    building it now against `INTEGER` overflow would tempt an int64-min
+    special case the grammar has nothing to observe by yet - see
+    `_docs/decisions.md`, 2026-09-01.
+    """
+
+    op: UnaryOperator
+    operand: Expr
+    position: Position
+
+
+@dataclass(frozen=True)
+class BinaryOp(Expr):
+    """A binary arithmetic, concatenation, or comparison expression:
+    `left <op> right`."""
+
+    op: Operator
+    left: Expr
+    right: Expr
+    position: Position
+
+
+@dataclass(frozen=True)
+class And(Expr):
+    """`left AND right`."""
+
+    left: Expr
+    right: Expr
+    position: Position
+
+
+@dataclass(frozen=True)
+class Or(Expr):
+    """`left OR right`."""
+
+    left: Expr
+    right: Expr
+    position: Position
+
+
+@dataclass(frozen=True)
+class Not(Expr):
+    """`NOT operand` - logical negation, not `NOT LIKE`/`NOT IN`/
+    `NOT BETWEEN`, which are the `negated` flag on `Like`/`In`/
+    `Between` instead (see those classes)."""
+
+    operand: Expr
+    position: Position
+
+
+@dataclass(frozen=True)
+class Is(Expr):
+    """`left IS right` / `left IS NOT right`, including the `IS NULL`
+    / `IS NOT NULL` spelling - see the module docstring for why those
+    are not separate node types."""
+
+    left: Expr
+    right: Expr
+    negated: bool
+    position: Position
+
+
+@dataclass(frozen=True)
+class Like(Expr):
+    """`left LIKE pattern` / `left NOT LIKE pattern`."""
+
+    left: Expr
+    pattern: Expr
+    negated: bool
+    position: Position
+
+
+@dataclass(frozen=True)
+class In(Expr):
+    """`left IN (values, ...)` / `left NOT IN (values, ...)`.
+
+    `values` may be empty (`IN ()` is valid SQL, always false -
+    confirmed against `sqlite3`) and holds full expressions, not just
+    literals: the grammar parses whatever a comma-separated expression
+    list yields here, which is also what lets #24 (Part B) detect a
+    subquery by peeking at the first token before parsing it as an
+    expression - restricting this to literals would take that check
+    away.
+    """
+
+    left: Expr
+    values: tuple[Expr, ...]
+    negated: bool
+    position: Position
+
+
+@dataclass(frozen=True)
+class Between(Expr):
+    """`operand BETWEEN low AND high` /
+    `operand NOT BETWEEN low AND high`.
+
+    The `AND` here is the operator's own syntax, not the general
+    `And` node - it is consumed directly by the parser and never
+    re-enters expression precedence, which is what stops it from
+    swallowing a trailing `AND <predicate>` that follows the whole
+    `BETWEEN` (issue #8's grooming: `x BETWEEN 1 AND 10 AND y = 1`
+    must parse as `(x BETWEEN 1 AND 10) AND (y = 1)`).
+    """
+
+    operand: Expr
+    low: Expr
+    high: Expr
+    negated: bool
+    position: Position
+
+
+# --- Statement nodes -------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SelectItem:
+    """One entry in a `SELECT` list: an expression and its optional
+    `AS alias`. Not part of the `Expr` hierarchy itself - it pairs an
+    expression with something that is not an expression (the alias
+    name), the same way a dict entry is not itself a key or a value.
+    """
+
+    expr: Expr
+    alias: str | None
+    position: Position
+
+
+@dataclass(frozen=True)
+class SelectStatement(Stmt):
+    """`SELECT <select_list> FROM <from_table> [WHERE <where>]`.
+
+    `from_table` is a bare, unresolved table name - not a node of its
+    own - and `where` is `None` when the clause is absent. Neither
+    `from_table` nor any `ColumnRef` inside this tree is checked
+    against a catalog; see the module docstring.
+    """
+
+    select_list: tuple[SelectItem, ...]
+    from_table: str
+    where: Expr | None
+    position: Position

--- a/src/historian/sql/parser.py
+++ b/src/historian/sql/parser.py
@@ -1,0 +1,541 @@
+"""Tokens -> AST.
+
+The third stage of the pipeline in `_docs/spec.md` §3. A hand-written
+recursive-descent / precedence-climbing parser over the token list
+`sql/lexer.py` produces - no parser generator, no table-driven engine,
+per `AGENTS.md`'s "keep the operator layer explicit and boring" (this
+module is not the operator layer, but the rule not to lean on Python's
+dynamism applies just as much to the piece meant to translate to a
+Rust `match` later).
+
+Scope: issue #8, Part A only
+-----------------------------
+
+`DISTINCT`, `GROUP BY`, `HAVING`, `ORDER BY`, `LIMIT`, `OFFSET`, any
+`JOIN`, and `CASE` are not implemented - see `sql/ast.py`'s module
+docstring. Ordinary SQL that uses them fails with a generic
+`ParseError` ("expected end of query" or similar), which is correct
+for now: naming the six §1 non-goals specifically (subqueries, CTEs,
+window functions, `UNION`/`INTERSECT`/`EXCEPT`, outer/cross joins, and
+would-be UDFs) by their own dedicated error is issue #24, not this
+module. This parser only ever raises `ParseError`.
+
+The precedence table
+---------------------
+
+Verified against `sqlite3` 3.51.0 during issue #8's grooming (see the
+issue thread and `_docs/decisions.md`), lowest to highest binding:
+
+    OR
+    AND
+    NOT
+    comparison tier 2: =  <>  !=  IS [NOT]  LIKE  IN  BETWEEN
+    comparison tier 1: <  <=  >  >=
+    +  -  (binary)
+    *  /
+    ||
+    +  -  (unary)
+
+The two comparison tiers are the detail most likely to be got wrong -
+a single flat "comparison" level parses every ordinary query the same
+way and only disagrees with SQLite on a chained comparison like
+`3 = 0 < 3`. Each precedence level below is one method, calling the
+next-tighter level for its operands, in exactly this order.
+
+Literal construction and the int64 boundary
+---------------------------------------------
+
+An `INTEGER` token's digit text becomes a Python `int` if it fits
+SQLite's int64 range, and a Python `float` otherwise - see
+`_int_literal_value` and `_docs/decisions.md`, 2026-09-01. This is
+construction, not comparison, and is unrelated to the 2026-08-27
+"numeric comparison is exact" decision - see that entry and `sql/
+ast.py`'s `Literal` docstring.
+"""
+
+from __future__ import annotations
+
+from historian.sql.ast import (
+    And,
+    Between,
+    BinaryOp,
+    ColumnRef,
+    Expr,
+    FunctionCall,
+    In,
+    Is,
+    Like,
+    Literal,
+    Not,
+    Operator,
+    Or,
+    SelectItem,
+    SelectStatement,
+    Star,
+    UnaryOp,
+    UnaryOperator,
+)
+from historian.sql.lexer import Position, Token, TokenType
+
+__all__ = ["ParseError", "parse"]
+
+#: SQLite's int64 range. A decimal `INTEGER` literal whose digit text
+#: exceeds this becomes a `float` instead of an `int` - see the module
+#: docstring and `_docs/decisions.md`, 2026-09-01. The lexer never
+#: emits a signed `INTEGER` token (a leading `-` is always its own
+#: `MINUS` token), so there is no negative bound to check here.
+_INT64_MAX = 9223372036854775807
+
+# Tier-1 comparison tokens (`<  <=  >  >=`) and the operator each maps to.
+_RELATIONAL_OPERATORS: dict[TokenType, Operator] = {
+    TokenType.LT: Operator.LT,
+    TokenType.LE: Operator.LE,
+    TokenType.GT: Operator.GT,
+    TokenType.GE: Operator.GE,
+}
+
+# Binary `+`/`-` and `*`/`/` tokens and the operator each maps to.
+_ADDITIVE_OPERATORS: dict[TokenType, Operator] = {
+    TokenType.PLUS: Operator.ADD,
+    TokenType.MINUS: Operator.SUB,
+}
+_MULTIPLICATIVE_OPERATORS: dict[TokenType, Operator] = {
+    TokenType.STAR: Operator.MUL,
+    TokenType.SLASH: Operator.DIV,
+}
+
+
+class ParseError(Exception):
+    """The token stream is not a valid v1 SELECT statement.
+
+    Carries the message and the `Position` of the offending token, the
+    same shape as `LexError` (`sql/lexer.py`), so a caller can report
+    it per `_docs/spec.md` §5 without a traceback ever reaching the
+    user.
+    """
+
+    def __init__(self, message: str, position: Position) -> None:
+        super().__init__(message)
+        self.position = position
+
+
+def parse(tokens: list[Token]) -> SelectStatement:
+    """Parse a complete `SELECT` statement from *tokens* (as produced
+    by `sql.lexer.tokenize`), including its trailing `EOF`.
+
+    Raises `ParseError` if *tokens* is not a single, complete `SELECT`
+    statement - including trailing garbage after one, and including an
+    optional trailing `;`, which is consumed if present.
+    """
+    parser = _Parser(tokens)
+    statement = parser.parse_select_statement()
+    parser.expect_end()
+    return statement
+
+
+def _describe(token: Token) -> str:
+    """A human-readable description of *token* for an error message,
+    e.g. `identifier 'LEFT'`, `string 'x'`, `end of query`. Matches
+    the shape used in `_docs/spec.md` §5's error examples."""
+    if token.type is TokenType.EOF:
+        return "end of query"
+    if token.type is TokenType.IDENTIFIER:
+        return f"identifier {token.text!r}"
+    if token.type is TokenType.STRING:
+        return f"string {token.text!r}"
+    if token.type in (TokenType.INTEGER, TokenType.REAL):
+        return f"number {token.text!r}"
+    return repr(token.text)
+
+
+def _int_literal_value(text: str) -> int | float:
+    """Convert an `INTEGER` token's digit text to the `Value` a
+    `Literal` should hold: a Python `int` if it fits SQLite's int64
+    range, a Python `float` otherwise.
+
+    Python's own `int()` never overflows, so this only happens because
+    the value is explicitly checked against the int64 bound and
+    converted - see the module docstring and `_docs/decisions.md`,
+    2026-09-01. int64-min is deliberately not special-cased: see
+    `UnaryOp`'s docstring in `sql/ast.py`.
+    """
+    value = int(text)
+    if value > _INT64_MAX:
+        return float(text)
+    return value
+
+
+class _Parser:
+    """Single-pass recursive-descent parser over `tokens`. Holds a
+    cursor index rather than consuming the list, so lookahead
+    (`_peek(1)`, `_peek(2)`) is just indexing."""
+
+    def __init__(self, tokens: list[Token]) -> None:
+        self._tokens = tokens
+        self._index = 0
+
+    # -- cursor -----------------------------------------------------
+
+    def _peek(self, ahead: int = 0) -> Token:
+        index = self._index + ahead
+        if index >= len(self._tokens):
+            # Every token stream ends with EOF (sql/lexer.py), so this
+            # only happens when *ahead* looks past it - return that
+            # trailing EOF rather than raising, so a `_peek(2)` used
+            # for lookahead near the end of a short, malformed query
+            # never itself crashes the parser.
+            return self._tokens[-1]
+        return self._tokens[index]
+
+    def _advance(self) -> Token:
+        token = self._peek()
+        if token.type is not TokenType.EOF:
+            self._index += 1
+        return token
+
+    def _check(self, token_type: TokenType) -> bool:
+        return self._peek().type is token_type
+
+    def _match(self, token_type: TokenType) -> bool:
+        if self._check(token_type):
+            self._advance()
+            return True
+        return False
+
+    def _expect(self, token_type: TokenType, expected: str) -> Token:
+        """Consume and return the current token if it is *token_type*,
+        else raise `ParseError` naming what was *expected*."""
+        token = self._peek()
+        if token.type is not token_type:
+            raise self._error(f"expected {expected}, found {_describe(token)}")
+        return self._advance()
+
+    def _error(self, message: str) -> ParseError:
+        return ParseError(message, self._peek().position)
+
+    def expect_end(self) -> None:
+        """After a complete statement: consume an optional trailing
+        `;`, then require `EOF`. Anything else - a second statement, an
+        unconsumed clause this grammar does not implement - is
+        rejected here rather than silently ignored."""
+        self._match(TokenType.SEMICOLON)
+        if not self._check(TokenType.EOF):
+            raise self._error(
+                f"expected end of query, found {_describe(self._peek())}"
+            )
+
+    # -- statement ----------------------------------------------------
+
+    def parse_select_statement(self) -> SelectStatement:
+        start = self._expect(TokenType.SELECT, "SELECT").position
+        select_list = self._parse_select_list()
+        self._expect(TokenType.FROM, "FROM")
+        from_table = self._expect(TokenType.IDENTIFIER, "a table name").text
+        where: Expr | None = None
+        if self._match(TokenType.WHERE):
+            where = self._parse_expr()
+        return SelectStatement(
+            select_list=select_list,
+            from_table=from_table,
+            where=where,
+            position=start,
+        )
+
+    def _parse_select_list(self) -> tuple[SelectItem, ...]:
+        items = [self._parse_select_item()]
+        while self._match(TokenType.COMMA):
+            items.append(self._parse_select_item())
+        return tuple(items)
+
+    def _parse_select_item(self) -> SelectItem:
+        start = self._peek().position
+        expr = self._parse_star_or_expr()
+        alias: str | None = None
+        if self._match(TokenType.AS):
+            alias = self._expect(TokenType.IDENTIFIER, "an alias name").text
+        return SelectItem(expr=expr, alias=alias, position=start)
+
+    def _parse_star_or_expr(self) -> Expr:
+        """A select-list item's expression, with `*`/`table.*` handled
+        first: `*` cannot start any other expression (it is a binary
+        operator token everywhere else), so seeing it here is
+        unambiguous."""
+        if self._check(TokenType.STAR):
+            token = self._advance()
+            return Star(table=None, position=token.position)
+        if (
+            self._check(TokenType.IDENTIFIER)
+            and self._peek(1).type is TokenType.DOT
+            and self._peek(2).type is TokenType.STAR
+        ):
+            table_token = self._advance()  # IDENTIFIER
+            self._advance()  # DOT
+            self._advance()  # STAR
+            return Star(table=table_token.text, position=table_token.position)
+        return self._parse_expr()
+
+    # -- expressions, loosest to tightest -----------------------------
+
+    def _parse_expr(self) -> Expr:
+        return self._parse_or()
+
+    def _parse_or(self) -> Expr:
+        left = self._parse_and()
+        while self._check(TokenType.OR):
+            self._advance()
+            right = self._parse_and()
+            left = Or(left=left, right=right, position=left.position)
+        return left
+
+    def _parse_and(self) -> Expr:
+        left = self._parse_not()
+        while self._check(TokenType.AND):
+            self._advance()
+            right = self._parse_not()
+            left = And(left=left, right=right, position=left.position)
+        return left
+
+    def _parse_not(self) -> Expr:
+        if self._check(TokenType.NOT):
+            token = self._advance()
+            operand = self._parse_not()  # NOT NOT x nests
+            return Not(operand=operand, position=token.position)
+        return self._parse_comparison()
+
+    def _parse_comparison(self) -> Expr:
+        """Comparison tier 2: `=  <>  !=  IS [NOT]  LIKE  IN  BETWEEN`,
+        each optionally preceded by `NOT` for `LIKE`/`IN`/`BETWEEN`
+        (that `NOT` is this operator's own modifier, not the general
+        prefix `Not` node - it can only appear here, after a left
+        operand already exists). A loop, not a single check: SQLite
+        chains same-tier comparisons left-associatively
+        (`1 = 1 = 1`, `1 IN (1,2) = 1` are both valid and confirmed
+        against `sqlite3` during grooming), so after building one
+        tier-2 node the loop checks again for another.
+        """
+        left = self._parse_relational()
+        while True:
+            token = self._peek()
+            if token.type in (TokenType.EQ, TokenType.NE):
+                self._advance()
+                op = Operator.EQ if token.type is TokenType.EQ else Operator.NE
+                right = self._parse_relational()
+                left = BinaryOp(op=op, left=left, right=right, position=left.position)
+            elif token.type is TokenType.IS:
+                left = self._parse_is(left)
+            elif token.type is TokenType.LIKE:
+                self._advance()
+                pattern = self._parse_relational()
+                left = Like(
+                    left=left, pattern=pattern, negated=False, position=left.position
+                )
+            elif token.type is TokenType.IN:
+                self._advance()
+                values = self._parse_in_list()
+                left = In(
+                    left=left, values=values, negated=False, position=left.position
+                )
+            elif token.type is TokenType.BETWEEN:
+                self._advance()
+                low, high = self._parse_between_bounds()
+                left = Between(
+                    operand=left,
+                    low=low,
+                    high=high,
+                    negated=False,
+                    position=left.position,
+                )
+            elif token.type is TokenType.NOT:
+                left = self._parse_negated_comparison(left)
+            else:
+                return left
+
+    def _parse_is(self, left: Expr) -> Expr:
+        self._advance()  # IS
+        negated = self._match(TokenType.NOT)
+        if self._check(TokenType.NULL):
+            null_token = self._advance()
+            right: Expr = Literal(value=None, position=null_token.position)
+        else:
+            right = self._parse_relational()
+        return Is(left=left, right=right, negated=negated, position=left.position)
+
+    def _parse_negated_comparison(self, left: Expr) -> Expr:
+        """`left NOT LIKE ...` / `left NOT IN (...)` /
+        `left NOT BETWEEN ... AND ...`, having already seen the `NOT`
+        token pending at the front of the stream."""
+        self._advance()  # NOT
+        if self._check(TokenType.LIKE):
+            self._advance()
+            pattern = self._parse_relational()
+            return Like(
+                left=left, pattern=pattern, negated=True, position=left.position
+            )
+        if self._check(TokenType.IN):
+            self._advance()
+            values = self._parse_in_list()
+            return In(left=left, values=values, negated=True, position=left.position)
+        if self._check(TokenType.BETWEEN):
+            self._advance()
+            low, high = self._parse_between_bounds()
+            return Between(
+                operand=left, low=low, high=high, negated=True, position=left.position
+            )
+        raise self._error(
+            "expected LIKE, IN or BETWEEN after NOT, found "
+            f"{_describe(self._peek())}"
+        )
+
+    def _parse_in_list(self) -> tuple[Expr, ...]:
+        self._expect(TokenType.LPAREN, "'(' after IN")
+        if self._check(TokenType.RPAREN):
+            self._advance()
+            return ()  # `IN ()` is valid SQL - always false, confirmed
+            # against sqlite3 during grooming.
+        values = [self._parse_expr()]
+        while self._match(TokenType.COMMA):
+            values.append(self._parse_expr())
+        self._expect(TokenType.RPAREN, "')'")
+        return tuple(values)
+
+    def _parse_between_bounds(self) -> tuple[Expr, Expr]:
+        """`BETWEEN low AND high`. Both bounds are parsed at tier 1
+        (`_parse_relational`), one level tighter than comparison tier 2
+        itself - consuming the `AND` directly here, rather than
+        recursing back into `_parse_and`, is what stops it from
+        swallowing a trailing `AND <predicate>` that follows the whole
+        `BETWEEN` (issue #8's grooming)."""
+        low = self._parse_relational()
+        self._expect(TokenType.AND, "AND")
+        high = self._parse_relational()
+        return low, high
+
+    def _parse_relational(self) -> Expr:
+        """Comparison tier 1: `<  <=  >  >=`."""
+        left = self._parse_additive()
+        while True:
+            op = _RELATIONAL_OPERATORS.get(self._peek().type)
+            if op is None:
+                return left
+            self._advance()
+            right = self._parse_additive()
+            left = BinaryOp(op=op, left=left, right=right, position=left.position)
+
+    def _parse_additive(self) -> Expr:
+        """Binary `+`/`-`."""
+        left = self._parse_multiplicative()
+        while True:
+            op = _ADDITIVE_OPERATORS.get(self._peek().type)
+            if op is None:
+                return left
+            self._advance()
+            right = self._parse_multiplicative()
+            left = BinaryOp(op=op, left=left, right=right, position=left.position)
+
+    def _parse_multiplicative(self) -> Expr:
+        """`*`/`/`."""
+        left = self._parse_concat()
+        while True:
+            op = _MULTIPLICATIVE_OPERATORS.get(self._peek().type)
+            if op is None:
+                return left
+            self._advance()
+            right = self._parse_concat()
+            left = BinaryOp(op=op, left=left, right=right, position=left.position)
+
+    def _parse_concat(self) -> Expr:
+        """`||`, binding tighter than `*`/`/` - confirmed against
+        `sqlite3` during grooming (`'a' || 1 + 1` is `1`, matching
+        `('a' || 1) + 1`, not `'a' || (1 + 1)` which is `'a2'`)."""
+        left = self._parse_unary()
+        while self._check(TokenType.CONCAT):
+            self._advance()
+            right = self._parse_unary()
+            left = BinaryOp(
+                op=Operator.CONCAT, left=left, right=right, position=left.position
+            )
+        return left
+
+    def _parse_unary(self) -> Expr:
+        """Prefix `+`/`-`, the tightest-binding operators in the
+        table. Right-recursive so `--x`/`+-x` nest instead of being
+        rejected."""
+        token = self._peek()
+        if token.type is TokenType.PLUS:
+            self._advance()
+            operand = self._parse_unary()
+            return UnaryOp(
+                op=UnaryOperator.POS, operand=operand, position=token.position
+            )
+        if token.type is TokenType.MINUS:
+            self._advance()
+            operand = self._parse_unary()
+            return UnaryOp(
+                op=UnaryOperator.NEG, operand=operand, position=token.position
+            )
+        return self._parse_primary()
+
+    # -- primary expressions ------------------------------------------
+
+    def _parse_primary(self) -> Expr:
+        token = self._peek()
+        if token.type is TokenType.INTEGER:
+            self._advance()
+            value = _int_literal_value(token.text)
+            return Literal(value=value, position=token.position)
+        if token.type is TokenType.REAL:
+            self._advance()
+            return Literal(value=float(token.text), position=token.position)
+        if token.type is TokenType.STRING:
+            self._advance()
+            return Literal(value=token.text, position=token.position)
+        if token.type is TokenType.NULL:
+            self._advance()
+            return Literal(value=None, position=token.position)
+        if token.type is TokenType.LPAREN:
+            self._advance()
+            inner = self._parse_expr()
+            self._expect(TokenType.RPAREN, "')'")
+            return inner
+        if token.type is TokenType.IDENTIFIER:
+            return self._parse_identifier_primary()
+        raise self._error(f"expected expression, found {_describe(token)}")
+
+    def _parse_identifier_primary(self) -> Expr:
+        """A bare identifier, resolved to one of three shapes by what
+        follows it: `name(` is a `FunctionCall`, `name.` is a
+        table-qualified `ColumnRef` (or `Star`, for `name.*`), and
+        anything else is a bare `ColumnRef`."""
+        first = self._advance()
+        if self._check(TokenType.LPAREN):
+            return self._parse_function_call(first)
+        if self._check(TokenType.DOT):
+            self._advance()
+            if self._check(TokenType.STAR):
+                self._advance()
+                return Star(table=first.text, position=first.position)
+            name = self._expect(TokenType.IDENTIFIER, "a column name after '.'").text
+            return ColumnRef(table=first.text, name=name, position=first.position)
+        return ColumnRef(table=None, name=first.text, position=first.position)
+
+    def _parse_function_call(self, name_token: Token) -> Expr:
+        self._advance()  # LPAREN
+        args: list[Expr] = []
+        if not self._check(TokenType.RPAREN):
+            args.append(self._parse_function_arg())
+            while self._match(TokenType.COMMA):
+                args.append(self._parse_function_arg())
+        self._expect(TokenType.RPAREN, "')'")
+        return FunctionCall(
+            name=name_token.text, args=tuple(args), position=name_token.position
+        )
+
+    def _parse_function_arg(self) -> Expr:
+        """A function-call argument, with a bare `*` (`count(*)`)
+        handled first the same way `_parse_star_or_expr` handles a
+        select-list `*` - it cannot start any other expression, so it
+        is unambiguous here too."""
+        if self._check(TokenType.STAR):
+            token = self._advance()
+            return Star(table=None, position=token.position)
+        return self._parse_expr()

--- a/src/historian/sql/parser.py
+++ b/src/historian/sql/parser.py
@@ -51,6 +51,49 @@ SQLite's int64 range, and a Python `float` otherwise - see
 construction, not comparison, and is unrelated to the 2026-08-27
 "numeric comparison is exact" decision - see that entry and `sql/
 ast.py`'s `Literal` docstring.
+
+Nesting depth: two limits, not one
+------------------------------------
+
+Deeply nested input must never raise a bare `RecursionError` - spec §5
+("never a traceback") and issue #8's round-1 QA finding, recorded in
+full in `_docs/decisions.md`, 2026-09-01. That entry has the measured
+numbers behind the two constants below; this is the shape of the fix.
+
+A recursive-descent parser pays Python stack frames for genuine
+recursion, and `sys.setrecursionlimit` is not a lever available here -
+raising it only moves the crash, and catching `RecursionError` after
+the fact would make whether a query parses depend on how much stack
+the caller already used before calling `parse()`, which breaks the
+determinism `AGENTS.md` requires. So depth has to be counted
+explicitly and checked before it becomes a Python-level problem, the
+same way SQLite counts `SQLITE_MAX_EXPR_DEPTH` rather than relying on
+its own C call stack.
+
+But not all recursion in this grammar is equal, which is why there are
+two limits:
+
+- A run of `(`, `NOT`, or unary `+`/`-` is pure repetition - `(((x)))`
+  is exactly `x`, `NOT NOT NOT x` is `x` wrapped three times - so
+  `_parse_primary`, `_parse_not`, and `_parse_unary` each parse their
+  run with a loop, not by recursing once per token. A loop costs one
+  iteration per token, not one Python stack frame, so these three
+  forms are bounded by the generous `_MAX_NESTING_DEPTH` (1000,
+  matching SQLite's own documented default).
+- Genuine recursion - parsing a *new* sub-expression from within
+  another one, which only happens for a parenthesised group's
+  contents, an `IN (...)` list value, or a function-call argument -
+  still goes through `_parse_expr` calling itself, and every such call
+  really does cost Python stack frames. That path is bounded by the
+  much smaller `_MAX_RECURSION_DEPTH` (50), sized from measured frame
+  costs with margin, not from SQLite's declared limit.
+
+Collapsing this to one limit does not work in either direction: a
+value low enough to be safe for genuine recursion is too low to accept
+ordinary deeply-parenthesised input SQLite itself accepts, and a value
+high enough to match SQLite's declared limit would let genuine
+recursion exhaust Python's real call stack before the counter ever
+fires.
 """
 
 from __future__ import annotations
@@ -85,6 +128,28 @@ __all__ = ["ParseError", "parse"]
 #: emits a signed `INTEGER` token (a leading `-` is always its own
 #: `MINUS` token), so there is no negative bound to check here.
 _INT64_MAX = 9223372036854775807
+
+#: How many `(`, `NOT`, or unary `+`/`-` tokens may run together before
+#: `_parse_primary`/`_parse_not`/`_parse_unary` (below) give up and
+#: raise `ParseError` instead of continuing. Mirrors SQLite's own
+#: `SQLITE_MAX_EXPR_DEPTH`, whose documented default is 1000
+#: (confirmed via `PRAGMA compile_options` against the `sqlite3`
+#: build used to verify this project's SQL behaviour) - see the
+#: module docstring and `_docs/decisions.md`, 2026-09-01, for why this
+#: is safe to enforce with a plain counter rather than Python's call
+#: stack: each of those three forms is parsed with a loop, not
+#: recursion, so a run this long costs one loop iteration per token,
+#: not one Python stack frame per token.
+_MAX_NESTING_DEPTH = 1000
+
+#: How many times `_parse_expr` may recursively re-enter itself while
+#: parsing one query - once per parenthesised group's contents, once
+#: per value inside an `IN (...)` list, and once per function-call
+#: argument. Unlike `_MAX_NESTING_DEPTH` above, this recursion is real
+#: Python call-stack recursion, so it cannot be set anywhere near
+#: 1000: see the module docstring and `_docs/decisions.md`,
+#: 2026-09-01 for the measured frame costs this is sized against.
+_MAX_RECURSION_DEPTH = 50
 
 # Tier-1 comparison tokens (`<  <=  >  >=`) and the operator each maps to.
 _RELATIONAL_OPERATORS: dict[TokenType, Operator] = {
@@ -173,6 +238,9 @@ class _Parser:
     def __init__(self, tokens: list[Token]) -> None:
         self._tokens = tokens
         self._index = 0
+        # How many nested `_parse_expr` calls are currently on the
+        # Python call stack - see `_MAX_RECURSION_DEPTH`.
+        self._depth = 0
 
     # -- cursor -----------------------------------------------------
 
@@ -277,7 +345,26 @@ class _Parser:
     # -- expressions, loosest to tightest -----------------------------
 
     def _parse_expr(self) -> Expr:
-        return self._parse_or()
+        """Parse one expression. The single choke point every genuine
+        recursive re-entry passes through - a parenthesised group's
+        contents, an `IN (...)` list value, a function-call argument -
+        so it is where `_MAX_RECURSION_DEPTH` is enforced, before
+        Python's own call stack ever gets close to its limit. See the
+        module docstring."""
+        start = self._peek()
+        self._depth += 1
+        if self._depth > _MAX_RECURSION_DEPTH:
+            self._depth -= 1
+            raise ParseError(
+                "expression nested too deeply "
+                f"(max {_MAX_RECURSION_DEPTH} levels of parentheses, "
+                "IN, or function-call nesting)",
+                start.position,
+            )
+        try:
+            return self._parse_or()
+        finally:
+            self._depth -= 1
 
     def _parse_or(self) -> Expr:
         left = self._parse_and()
@@ -296,11 +383,26 @@ class _Parser:
         return left
 
     def _parse_not(self) -> Expr:
-        if self._check(TokenType.NOT):
+        """`NOT NOT NOT x` nests. An explicit loop rather than the
+        obvious `self._parse_not()` self-recursion for the operand:
+        that would cost one Python stack frame per `NOT`, and this is
+        one of the two forms `_MAX_NESTING_DEPTH` (not
+        `_MAX_RECURSION_DEPTH`) governs precisely because it doesn't
+        have to - see the module docstring."""
+        positions: list[Position] = []
+        while self._check(TokenType.NOT):
             token = self._advance()
-            operand = self._parse_not()  # NOT NOT x nests
-            return Not(operand=operand, position=token.position)
-        return self._parse_comparison()
+            positions.append(token.position)
+            if len(positions) > _MAX_NESTING_DEPTH:
+                raise ParseError(
+                    "expression nested too deeply "
+                    f"(max {_MAX_NESTING_DEPTH} levels of NOT)",
+                    token.position,
+                )
+        node = self._parse_comparison()
+        for position in reversed(positions):
+            node = Not(operand=node, position=position)
+        return node
 
     def _parse_comparison(self) -> Expr:
         """Comparison tier 2: `=  <>  !=  IS [NOT]  LIKE  IN  BETWEEN`,
@@ -458,22 +560,32 @@ class _Parser:
 
     def _parse_unary(self) -> Expr:
         """Prefix `+`/`-`, the tightest-binding operators in the
-        table. Right-recursive so `--x`/`+-x` nest instead of being
-        rejected."""
-        token = self._peek()
-        if token.type is TokenType.PLUS:
+        table. `--x`/`+-x` nest, via an explicit loop rather than
+        `self._parse_unary()` self-recursion on the operand - the same
+        reasoning as `_parse_not` above: this is governed by
+        `_MAX_NESTING_DEPTH`, not `_MAX_RECURSION_DEPTH`, because a
+        loop costs no Python stack per `+`/`-`."""
+        ops: list[tuple[UnaryOperator, Position]] = []
+        while True:
+            token = self._peek()
+            if token.type is TokenType.PLUS:
+                op = UnaryOperator.POS
+            elif token.type is TokenType.MINUS:
+                op = UnaryOperator.NEG
+            else:
+                break
             self._advance()
-            operand = self._parse_unary()
-            return UnaryOp(
-                op=UnaryOperator.POS, operand=operand, position=token.position
-            )
-        if token.type is TokenType.MINUS:
-            self._advance()
-            operand = self._parse_unary()
-            return UnaryOp(
-                op=UnaryOperator.NEG, operand=operand, position=token.position
-            )
-        return self._parse_primary()
+            ops.append((op, token.position))
+            if len(ops) > _MAX_NESTING_DEPTH:
+                raise ParseError(
+                    "expression nested too deeply "
+                    f"(max {_MAX_NESTING_DEPTH} levels of unary +/-)",
+                    token.position,
+                )
+        node = self._parse_primary()
+        for op, position in reversed(ops):
+            node = UnaryOp(op=op, operand=node, position=position)
+        return node
 
     # -- primary expressions ------------------------------------------
 
@@ -493,9 +605,27 @@ class _Parser:
             self._advance()
             return Literal(value=None, position=token.position)
         if token.type is TokenType.LPAREN:
-            self._advance()
+            # A run of `(` is stripped with a loop, not by recursing
+            # once per paren: `(expr)` produces no AST node of its own
+            # (`inner` is returned unchanged below), so however many
+            # parens wrap one expression, only one `_parse_expr` call
+            # is needed for its contents. Bounded by
+            # `_MAX_NESTING_DEPTH`, not `_MAX_RECURSION_DEPTH` - the
+            # module docstring explains why this one form gets the
+            # much larger limit.
+            depth = 0
+            while self._check(TokenType.LPAREN):
+                paren = self._advance()
+                depth += 1
+                if depth > _MAX_NESTING_DEPTH:
+                    raise ParseError(
+                        "expression nested too deeply "
+                        f"(max {_MAX_NESTING_DEPTH} levels of parentheses)",
+                        paren.position,
+                    )
             inner = self._parse_expr()
-            self._expect(TokenType.RPAREN, "')'")
+            for _ in range(depth):
+                self._expect(TokenType.RPAREN, "')'")
             return inner
         if token.type is TokenType.IDENTIFIER:
             return self._parse_identifier_primary()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,548 @@
+"""Tests for historian.sql.parser and historian.sql.ast.
+
+Issue #8 (Part A) and issue #17 (the int64 literal boundary), grooming
+and all sqlite3-verified precedence/overflow evidence in the issue
+threads for both. Every expected precedence or overflow behaviour here
+was checked against the `sqlite3` command-line tool (3.51.0) during
+grooming rather than reasoned about from memory - the query used is
+quoted above each group, matching `tests/test_lexer.py` and `tests/
+test_values.py`'s convention.
+"""
+
+import dataclasses
+
+import pytest
+
+from historian.sql.ast import (
+    And,
+    Between,
+    BinaryOp,
+    ColumnRef,
+    Expr,
+    FunctionCall,
+    In,
+    Is,
+    Like,
+    Literal,
+    Not,
+    Operator,
+    Or,
+    SelectStatement,
+    Star,
+    Stmt,
+    UnaryOp,
+    UnaryOperator,
+)
+from historian.sql.lexer import Position, tokenize
+from historian.sql.parser import ParseError, parse
+
+INT64_MAX = 9223372036854775807
+
+
+def _parse(sql: str) -> SelectStatement:
+    return parse(tokenize(sql))
+
+
+def _where(sql: str) -> Expr:
+    """Parse *sql* and return its WHERE expression, asserting it is
+    present."""
+    stmt = _parse(sql)
+    assert stmt.where is not None
+    return stmt.where
+
+
+def _select_expr(sql: str) -> Expr:
+    """Parse *sql* and return its single select-list item's
+    expression."""
+    stmt = _parse(sql)
+    assert len(stmt.select_list) == 1
+    return stmt.select_list[0].expr
+
+
+# --- The target query and basic SELECT/FROM/WHERE shape ------------------
+
+
+def test_target_query_shape():
+    """`_docs/spec.md`'s M2 target query: two bare columns, a FROM
+    table name, and an `=` predicate between a ColumnRef and a string
+    Literal."""
+    stmt = _parse("SELECT path, author_name FROM blame WHERE path = 'src/a.py'")
+    assert isinstance(stmt, SelectStatement)
+    assert isinstance(stmt, Stmt)
+    assert len(stmt.select_list) == 2
+    first, second = stmt.select_list
+    assert first.expr == ColumnRef(
+        table=None, name="path", position=first.expr.position
+    )
+    assert second.expr == ColumnRef(
+        table=None, name="author_name", position=second.expr.position
+    )
+    assert stmt.from_table == "blame"
+    assert isinstance(stmt.where, BinaryOp)
+    assert stmt.where.op is Operator.EQ
+    assert stmt.where.left == ColumnRef(
+        table=None, name="path", position=stmt.where.left.position
+    )
+    assert stmt.where.right == Literal(
+        value="src/a.py", position=stmt.where.right.position
+    )
+
+
+def test_select_star():
+    stmt = _parse("SELECT * FROM blame")
+    assert len(stmt.select_list) == 1
+    item = stmt.select_list[0]
+    assert isinstance(item.expr, Star)
+    assert not isinstance(item.expr, ColumnRef)
+    assert item.expr.table is None
+
+
+def test_qualified_star():
+    stmt = _parse("SELECT blame.* FROM blame")
+    item = stmt.select_list[0]
+    assert isinstance(item.expr, Star)
+    assert item.expr.table == "blame"
+
+
+def test_alias_and_qualified_column_are_captured_separately():
+    stmt = _parse("SELECT path AS p, blame.author_name FROM blame")
+    first, second = stmt.select_list
+    assert first.expr == ColumnRef(
+        table=None, name="path", position=first.expr.position
+    )
+    assert first.alias == "p"
+    assert second.alias is None
+    assert isinstance(second.expr, ColumnRef)
+    assert second.expr.table == "blame"
+    assert second.expr.name == "author_name"
+
+
+def test_where_is_optional():
+    stmt = _parse("SELECT path FROM blame")
+    assert stmt.where is None
+
+
+def test_expression_alias_requires_as_keyword():
+    """The v1 grammar (`_docs/spec.md` §1) writes `<expr> [AS alias]`
+    - `AS` is mandatory when an alias is present, not the optional-AS
+    SQLite itself also allows."""
+    stmt = _parse("SELECT path FROM blame")
+    assert stmt.select_list[0].alias is None
+
+
+# --- FunctionCall (bare IDENTIFIER LPAREN ... RPAREN) ---------------------
+
+
+def test_function_call_with_star_arg():
+    expr = _select_expr("SELECT count(*) FROM blame")
+    assert isinstance(expr, FunctionCall)
+    assert expr.name == "count"
+    assert len(expr.args) == 1
+    assert isinstance(expr.args[0], Star)
+    assert expr.args[0].table is None
+
+
+def test_function_call_with_column_arg():
+    expr = _select_expr("SELECT sum(line_no) FROM blame")
+    assert isinstance(expr, FunctionCall)
+    assert expr.name == "sum"
+    assert expr.args == (
+        ColumnRef(table=None, name="line_no", position=expr.args[0].position),
+    )
+
+
+def test_function_call_with_multiple_args():
+    expr = _select_expr("SELECT foo(a, b) FROM blame")
+    assert isinstance(expr, FunctionCall)
+    assert expr.name == "foo"
+    assert len(expr.args) == 2
+
+
+def test_function_call_with_no_args():
+    expr = _select_expr("SELECT foo() FROM blame")
+    assert isinstance(expr, FunctionCall)
+    assert expr.args == ()
+
+
+def test_function_call_with_expression_arg():
+    expr = _select_expr("SELECT foo(a + 1) FROM blame")
+    assert isinstance(expr, FunctionCall)
+    assert isinstance(expr.args[0], BinaryOp)
+
+
+# --- Precedence -----------------------------------------------------------
+#
+# `select 3 = 0 < 3;` -> 0, confirmed against sqlite3 during grooming:
+# only possible if `<` binds tighter than `=`, giving `3 = (0 < 3)`.
+
+
+def test_and_binds_tighter_than_or():
+    expr = _where("SELECT path FROM blame WHERE a=1 AND b=2 OR c=3")
+    assert isinstance(expr, Or)
+    assert isinstance(expr.left, And)
+    assert expr.right == BinaryOp(
+        op=Operator.EQ,
+        left=ColumnRef(table=None, name="c", position=expr.right.left.position),
+        right=Literal(value=3, position=expr.right.right.position),
+        position=expr.right.position,
+    )
+
+
+def test_not_binds_tighter_than_and_looser_than_comparison():
+    expr = _where("SELECT path FROM blame WHERE NOT a=1 AND b=2")
+    assert isinstance(expr, And)
+    assert isinstance(expr.left, Not)
+    assert isinstance(expr.left.operand, BinaryOp)
+    assert expr.left.operand.op is Operator.EQ
+
+
+def test_between_and_does_not_swallow_trailing_predicate():
+    """`select 5 between 1 and 10 and 0;` -> 0, confirmed against
+    sqlite3 during grooming: BETWEEN's own AND must not consume the
+    trailing `AND y=1`."""
+    expr = _where("SELECT path FROM blame WHERE x BETWEEN 1 AND 10 AND y=1")
+    assert isinstance(expr, And)
+    assert isinstance(expr.left, Between)
+    assert expr.left.low == Literal(value=1, position=expr.left.low.position)
+    assert expr.left.high == Literal(value=10, position=expr.left.high.position)
+    assert expr.right == BinaryOp(
+        op=Operator.EQ,
+        left=ColumnRef(table=None, name="y", position=expr.right.left.position),
+        right=Literal(value=1, position=expr.right.right.position),
+        position=expr.right.position,
+    )
+
+
+def test_concat_binds_tighter_than_plus():
+    """`select 'a' || 1 + 1;` -> 1, confirmed against sqlite3 during
+    grooming: matches `('a' || 1) + 1`, not `'a' || (1 + 1)` (= 'a2')."""
+    expr = _select_expr("SELECT 'a' || 1 + 1 FROM blame")
+    assert isinstance(expr, BinaryOp)
+    assert expr.op is Operator.ADD
+    assert isinstance(expr.left, BinaryOp)
+    assert expr.left.op is Operator.CONCAT
+    assert expr.left.left == Literal(value="a", position=expr.left.left.position)
+    assert expr.left.right == Literal(value=1, position=expr.left.right.position)
+    assert expr.right == Literal(value=1, position=expr.right.position)
+
+
+def test_multiplication_binds_tighter_than_addition():
+    expr = _select_expr("SELECT 2 + 3 * 4 FROM blame")
+    assert isinstance(expr, BinaryOp)
+    assert expr.op is Operator.ADD
+    assert expr.left == Literal(value=2, position=expr.left.position)
+    assert isinstance(expr.right, BinaryOp)
+    assert expr.right.op is Operator.MUL
+
+
+def test_concat_binds_tighter_than_multiplication():
+    """`select 'a' || 1 * 2;` -> 0, confirmed against sqlite3: matches
+    `('a' || 1) * 2` (= 0, numeric affinity of 'a1' is 0), not
+    `'a' || (1 * 2)` (= 'a2'). `||` binding tighter than `*` means it
+    grabs the shared operand `1` first, so `*` ends up as the
+    outermost node with the concat as its left operand."""
+    expr = _select_expr("SELECT 'a' || 1 * 2 FROM blame")
+    assert isinstance(expr, BinaryOp)
+    assert expr.op is Operator.MUL
+    assert isinstance(expr.left, BinaryOp)
+    assert expr.left.op is Operator.CONCAT
+
+
+def test_unary_minus_binds_tighter_than_concat():
+    expr = _select_expr("SELECT -1 || 'x' FROM blame")
+    assert isinstance(expr, BinaryOp)
+    assert expr.op is Operator.CONCAT
+    assert isinstance(expr.left, UnaryOp)
+    assert expr.left.op is UnaryOperator.NEG
+
+
+def test_relational_binds_tighter_than_equality():
+    """`select 3 = 0 < 3;` -> 0, confirmed against sqlite3 during
+    grooming."""
+    expr = _select_expr("SELECT 3 = 0 < 3 FROM blame")
+    assert isinstance(expr, BinaryOp)
+    assert expr.op is Operator.EQ
+    assert expr.left == Literal(value=3, position=expr.left.position)
+    assert isinstance(expr.right, BinaryOp)
+    assert expr.right.op is Operator.LT
+
+
+def test_arithmetic_binds_tighter_than_relational():
+    expr = _select_expr("SELECT 2 + 3 < 10 FROM blame")
+    assert isinstance(expr, BinaryOp)
+    assert expr.op is Operator.LT
+    assert isinstance(expr.left, BinaryOp)
+    assert expr.left.op is Operator.ADD
+
+
+def test_chained_equality_is_left_associative():
+    """`select 1 = 1 = 1;` -> 1, confirmed against sqlite3 during
+    grooming: comparison-tier operators chain rather than requiring
+    parentheses."""
+    expr = _select_expr("SELECT 1 = 1 = 1 FROM blame")
+    assert isinstance(expr, BinaryOp)
+    assert expr.op is Operator.EQ
+    assert isinstance(expr.left, BinaryOp)
+    assert expr.left.op is Operator.EQ
+    assert expr.right == Literal(value=1, position=expr.right.position)
+
+
+def test_between_operands_may_contain_arithmetic():
+    """`select 3 between 1+1 and 10;` -> 1, confirmed against sqlite3
+    during grooming: BETWEEN's bounds parse at tier 1, which includes
+    everything tighter, arithmetic included."""
+    expr = _where("SELECT path FROM blame WHERE x BETWEEN 1 + 1 AND 10")
+    assert isinstance(expr, Between)
+    assert isinstance(expr.low, BinaryOp)
+    assert expr.low.op is Operator.ADD
+
+
+# --- NOT-compound forms parse without error --------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT a NOT LIKE 'x%' FROM blame",
+        "SELECT a NOT IN (1, 2) FROM blame",
+        "SELECT a NOT BETWEEN 1 AND 2 FROM blame",
+        "SELECT a IS NOT NULL FROM blame",
+    ],
+)
+def test_not_compound_forms_parse_without_error(sql):
+    _parse(sql)  # must not raise
+
+
+def test_not_like():
+    expr = _select_expr("SELECT a NOT LIKE 'x%' FROM blame")
+    assert isinstance(expr, Like)
+    assert expr.negated is True
+
+
+def test_not_in():
+    expr = _select_expr("SELECT a NOT IN (1, 2) FROM blame")
+    assert isinstance(expr, In)
+    assert expr.negated is True
+    assert len(expr.values) == 2
+
+
+def test_not_between():
+    expr = _select_expr("SELECT a NOT BETWEEN 1 AND 2 FROM blame")
+    assert isinstance(expr, Between)
+    assert expr.negated is True
+
+
+def test_is_not_null():
+    """`x IS NOT NULL` is `Is(x, Literal(None), negated=True)` - see
+    sql/ast.py's module docstring for why IS NULL/IS NOT NULL are not
+    their own node types."""
+    expr = _select_expr("SELECT a IS NOT NULL FROM blame")
+    assert isinstance(expr, Is)
+    assert expr.negated is True
+    assert expr.right == Literal(value=None, position=expr.right.position)
+
+
+def test_is_null():
+    expr = _select_expr("SELECT a IS NULL FROM blame")
+    assert isinstance(expr, Is)
+    assert expr.negated is False
+    assert expr.right == Literal(value=None, position=expr.right.position)
+
+
+def test_plain_is():
+    expr = _select_expr("SELECT a IS b FROM blame")
+    assert isinstance(expr, Is)
+    assert expr.negated is False
+    assert expr.right == ColumnRef(table=None, name="b", position=expr.right.position)
+
+
+def test_in_empty_list():
+    """`select 1 in ();` -> 0 (always false, not an error), confirmed
+    against sqlite3 during grooming."""
+    expr = _select_expr("SELECT a IN () FROM blame")
+    assert isinstance(expr, In)
+    assert expr.values == ()
+
+
+# --- Literal construction and the int64 boundary (issue #17) -------------
+#
+# `sqlite3 :memory: "select 9223372036854775807, typeof(...);"` ->
+# `9223372036854775807|integer`. One past that ->
+# `9.22337203685478e+18|real`. Confirmed during grooming.
+
+
+def test_int64_max_stays_an_int():
+    expr = _select_expr("SELECT 9223372036854775807 FROM blame")
+    assert isinstance(expr, Literal)
+    assert expr.value == 9223372036854775807
+    assert isinstance(expr.value, int)
+
+
+def test_one_past_int64_max_becomes_a_float():
+    expr = _select_expr("SELECT 9223372036854775808 FROM blame")
+    assert isinstance(expr, Literal)
+    assert isinstance(expr.value, float)
+    assert expr.value == 9223372036854775808.0
+
+
+def test_arbitrarily_large_integer_becomes_a_float_not_an_error():
+    """Python's own `int()` never overflows, so this only happens
+    because literal construction explicitly checks the int64 bound."""
+    expr = _select_expr("SELECT 99999999999999999999999999999999 FROM blame")
+    assert isinstance(expr, Literal)
+    assert isinstance(expr.value, float)
+    assert not isinstance(expr.value, int)
+
+
+def test_negative_int64_min_parses_without_error():
+    """Whether this folds to a negative int Literal or stays a UnaryOp
+    wrapping a float Literal is unspecified (issue #8's grooming) - it
+    is a UnaryOp wrapping a float here, and int64-min is deliberately
+    not special-cased (see _docs/decisions.md, 2026-09-01, and
+    UnaryOp's docstring in sql/ast.py). Only "parses, and is
+    numerically -9223372036854775808" is asserted."""
+    expr = _select_expr("SELECT -9223372036854775808 FROM blame")
+    assert isinstance(expr, UnaryOp)
+    assert expr.op is UnaryOperator.NEG
+    assert isinstance(expr.operand, Literal)
+    assert -expr.operand.value == -9223372036854775808
+
+
+def test_real_literal_is_a_float():
+    expr = _select_expr("SELECT 1.5 FROM blame")
+    assert expr == Literal(value=1.5, position=expr.position)
+
+
+def test_string_literal_is_a_str():
+    expr = _select_expr("SELECT 'x' FROM blame")
+    assert expr == Literal(value="x", position=expr.position)
+
+
+def test_null_literal_is_none():
+    expr = _select_expr("SELECT NULL FROM blame")
+    assert expr == Literal(value=None, position=expr.position)
+    assert isinstance(expr, Literal)
+
+
+# --- Parse errors -----------------------------------------------------
+
+
+def test_missing_from_raises_parse_error_at_offending_token():
+    with pytest.raises(ParseError) as excinfo:
+        _parse("SELECT path WHERE path = 'x'")
+    assert isinstance(excinfo.value.position, Position)
+    # WHERE, not SELECT or path, is where FROM was expected.
+    assert excinfo.value.position.column == tokenize(
+        "SELECT path WHERE path = 'x'"
+    )[2].position.column
+
+
+def test_empty_select_list_raises_parse_error():
+    with pytest.raises(ParseError):
+        _parse("SELECT FROM blame")
+
+
+def test_dangling_where_raises_parse_error():
+    with pytest.raises(ParseError):
+        _parse("SELECT path FROM blame WHERE")
+
+
+def test_parse_error_message_names_what_was_expected():
+    with pytest.raises(ParseError) as excinfo:
+        _parse("SELECT path WHERE path = 'x'")
+    assert "FROM" in str(excinfo.value)
+
+
+def test_trailing_garbage_after_statement_is_a_parse_error():
+    with pytest.raises(ParseError):
+        _parse("SELECT path FROM blame EXTRA")
+
+
+def test_trailing_semicolon_is_consumed():
+    stmt = _parse("SELECT path FROM blame;")
+    assert stmt.from_table == "blame"
+
+
+def test_no_traceback_reaches_caller_as_syntax_or_value_error():
+    """The parser raises exactly ParseError for malformed input, never
+    a bare SyntaxError/ValueError leaking from Python's own int()/
+    float() or list indexing."""
+    for sql in [
+        "SELECT path WHERE path = 'x'",
+        "SELECT FROM blame",
+        "SELECT path FROM blame WHERE",
+        "SELECT path FROM",
+        "SELECT (1 FROM blame",
+        "SELECT 1 +",
+    ]:
+        with pytest.raises(ParseError):
+            _parse(sql)
+
+
+# --- Module and node-shape constraints -------------------------------
+
+
+def test_select_statement_is_a_stmt_not_an_expr():
+    stmt = _parse("SELECT path FROM blame")
+    assert isinstance(stmt, Stmt)
+    assert not isinstance(stmt, Expr)
+
+
+def test_ast_nodes_are_frozen():
+    lit = Literal(value=1, position=Position(line=1, column=1, offset=0))
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        lit.value = 2  # type: ignore[misc]
+
+
+def test_every_expression_node_carries_a_position():
+    stmt = _parse("SELECT path, 1 + 2, a AND b FROM blame WHERE x = 1")
+    assert isinstance(stmt.position, Position)
+    for item in stmt.select_list:
+        assert isinstance(item.expr.position, Position)
+    assert isinstance(stmt.where.position, Position)
+
+
+def test_parser_module_has_no_git_or_subprocess_import():
+    """AGENTS.md: 'The parser, the planner and the executor are plain
+    Python with no git and no subprocess imports.'"""
+    import ast as python_ast
+    import inspect
+
+    import historian.sql.parser as parser_module
+
+    source = inspect.getsource(parser_module)
+    tree = python_ast.parse(source)
+    imported_names = set()
+    for node in python_ast.walk(tree):
+        if isinstance(node, python_ast.Import):
+            imported_names.update(alias.name for alias in node.names)
+        elif isinstance(node, python_ast.ImportFrom) and node.module:
+            imported_names.add(node.module)
+    assert "git" not in imported_names
+    assert "subprocess" not in imported_names
+
+
+def test_parser_never_imports_schema_row_or_table_catalog():
+    """The parser is schema-blind: it never checks that `blame`, or any
+    column, actually exists (issue #8's grooming, 'what this issue
+    does not own')."""
+    import inspect
+
+    import historian.sql.parser as parser_module
+
+    source = inspect.getsource(parser_module)
+    assert "Schema" not in source
+    assert "Row" not in source
+
+
+def test_unresolved_column_ref_and_from_table():
+    """A ColumnRef is unresolved (table: str | None, name: str) and
+    FROM is a bare, unresolved table name - neither is checked against
+    a catalog."""
+    stmt = _parse("SELECT nonexistent_column FROM nonexistent_table")
+    assert stmt.from_table == "nonexistent_table"
+    assert stmt.select_list[0].expr == ColumnRef(
+        table=None,
+        name="nonexistent_column",
+        position=stmt.select_list[0].expr.position,
+    )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -479,6 +479,170 @@ def test_no_traceback_reaches_caller_as_syntax_or_value_error():
             _parse(sql)
 
 
+# --- Nesting depth: no RecursionError may ever escape (issue #8, round 1) -
+#
+# QA found `parse()` crashing with a raw, unhandled `RecursionError`
+# on deeply nested parentheses: 89 levels of `(...)` parsed, 90 raised
+# a bare traceback. `sqlite3 3.51.0` accepts 90 levels of bare parens
+# and returns `1`. Two requirements follow, per AGENTS.md ("where
+# historian and SQLite disagree, SQLite is right") and spec §5 ("never
+# a traceback"): historian must parse everything SQLite parses here,
+# and must raise `ParseError` - never let `RecursionError` escape -
+# wherever it does decline to go further.
+#
+# Measured directly against this build of `sqlite3 3.51.0` (see
+# `_docs/decisions.md` for the full numbers and how they were taken):
+# its *documented* limit is `SQLITE_MAX_EXPR_DEPTH` = 1000 (confirmed
+# via `PRAGMA compile_options`), but its own parser's internal stack
+# overflows well before that in practice - at 93 levels of bare
+# parens, and at 31 levels of nested function calls or nested
+# `IN`-lists. `sql/parser.py`'s two limits below (`_MAX_NESTING_DEPTH`
+# and `_MAX_RECURSION_DEPTH`) are chosen to clear all three of those
+# numbers with room to spare, while staying safely inside Python's own
+# recursion budget regardless of how much stack the caller of parse()
+# has already used - see the module docstring for why there are two
+# limits and not one.
+
+_MAX_NESTING_DEPTH = 1000  # sql/parser.py's _MAX_NESTING_DEPTH
+_MAX_RECURSION_DEPTH = 50  # sql/parser.py's _MAX_RECURSION_DEPTH
+
+
+def _nested_parens(depth: int) -> str:
+    return f"SELECT {'(' * depth}1{')' * depth} FROM blame"
+
+
+def _not_chain(depth: int) -> str:
+    return f"SELECT {'NOT ' * depth}1 FROM blame"
+
+
+def _unary_chain(depth: int) -> str:
+    # Space-separated: `--` lexes as a SQL line comment, which would
+    # swallow the rest of the query instead of producing `depth`
+    # separate MINUS tokens.
+    return f"SELECT {'- ' * depth}1 FROM blame"
+
+
+def _nested_in(depth: int) -> str:
+    return f"SELECT {'a IN (' * depth}1{')' * depth} FROM blame"
+
+
+def _nested_calls(depth: int) -> str:
+    return f"SELECT {'f(' * depth}1{')' * depth} FROM blame"
+
+
+def test_qa_reported_depth_parses_like_sqlite():
+    """The exact case QA reported: `sqlite3` accepts 90 levels of bare
+    parens and returns `1`. historian must too - a depth limit is only
+    correct if it sits above what SQLite actually accepts."""
+    expr = _select_expr(_nested_parens(90))
+    assert expr == Literal(value=1, position=expr.position)
+
+
+def test_nested_parens_up_to_max_depth_parse():
+    expr = _select_expr(_nested_parens(_MAX_NESTING_DEPTH))
+    assert expr == Literal(value=1, position=expr.position)
+
+
+def test_nested_parens_beyond_max_depth_raise_parse_error():
+    with pytest.raises(ParseError) as excinfo:
+        _parse(_nested_parens(_MAX_NESTING_DEPTH + 1))
+    assert isinstance(excinfo.value.position, Position)
+
+
+def test_absurdly_deep_nested_parens_raise_parse_error_not_recursion_error():
+    """No RecursionError may escape at any depth, including far beyond
+    anything a real query - or a fuzzer - would plausibly generate."""
+    with pytest.raises(ParseError):
+        _parse(_nested_parens(20_000))
+
+
+def test_not_chain_up_to_max_depth_parses():
+    expr = _select_expr(_not_chain(_MAX_NESTING_DEPTH))
+    assert isinstance(expr, Not)
+
+
+def test_not_chain_beyond_max_depth_raises_parse_error():
+    with pytest.raises(ParseError) as excinfo:
+        _parse(_not_chain(_MAX_NESTING_DEPTH + 1))
+    assert isinstance(excinfo.value.position, Position)
+
+
+def test_absurdly_long_not_chain_raises_parse_error_not_recursion_error():
+    with pytest.raises(ParseError):
+        _parse(_not_chain(20_000))
+
+
+def test_unary_chain_up_to_max_depth_parses():
+    expr = _select_expr(_unary_chain(_MAX_NESTING_DEPTH))
+    assert isinstance(expr, UnaryOp)
+
+
+def test_unary_chain_beyond_max_depth_raises_parse_error():
+    with pytest.raises(ParseError) as excinfo:
+        _parse(_unary_chain(_MAX_NESTING_DEPTH + 1))
+    assert isinstance(excinfo.value.position, Position)
+
+
+def test_absurdly_long_unary_chain_raises_parse_error_not_recursion_error():
+    with pytest.raises(ParseError):
+        _parse(_unary_chain(20_000))
+
+
+def test_nested_in_list_up_to_recursion_depth_parses():
+    # Each of the `depth` nested `IN (...)` layers costs one
+    # `_parse_expr` re-entry *on top of* the one already spent parsing
+    # the select-list item itself, so `depth` layers reach
+    # `depth + 1` on `self._depth` - `_MAX_RECURSION_DEPTH - 1` layers
+    # is the deepest that stays at exactly `_MAX_RECURSION_DEPTH`.
+    expr = _select_expr(_nested_in(_MAX_RECURSION_DEPTH - 1))
+    assert isinstance(expr, In)
+
+
+def test_nested_in_list_beyond_recursion_depth_raises_parse_error():
+    with pytest.raises(ParseError) as excinfo:
+        _parse(_nested_in(_MAX_RECURSION_DEPTH))
+    assert isinstance(excinfo.value.position, Position)
+
+
+def test_absurdly_deep_nested_in_list_raises_parse_error_not_recursion_error():
+    with pytest.raises(ParseError):
+        _parse(_nested_in(20_000))
+
+
+def test_nested_function_calls_up_to_recursion_depth_parse():
+    # Same off-by-one as the IN-list case above: `depth` nested calls
+    # cost `depth + 1` on `self._depth`.
+    expr = _select_expr(_nested_calls(_MAX_RECURSION_DEPTH - 1))
+    assert isinstance(expr, FunctionCall)
+
+
+def test_nested_function_calls_beyond_recursion_depth_raises_parse_error():
+    with pytest.raises(ParseError) as excinfo:
+        _parse(_nested_calls(_MAX_RECURSION_DEPTH))
+    assert isinstance(excinfo.value.position, Position)
+
+
+def test_absurdly_deep_nested_function_calls_raise_parse_error_not_recursion_error():
+    with pytest.raises(ParseError):
+        _parse(_nested_calls(20_000))
+
+
+def test_deep_nesting_parse_error_message_names_the_problem():
+    with pytest.raises(ParseError) as excinfo:
+        _parse(_nested_parens(_MAX_NESTING_DEPTH + 1))
+    assert "nest" in str(excinfo.value).lower()
+
+
+def test_long_and_chain_still_parses_unaffected_by_depth_limit():
+    """AND/OR/comparison chaining is loop-based, not recursive, so it
+    was never at risk of RecursionError - unaffected by this fix. QA
+    already checked a 500-clause chain by hand; this pins it as a
+    regression test."""
+    sql = "SELECT " + " AND ".join(["a"] * 5000) + " FROM blame"
+    expr = _select_expr(sql)
+    assert isinstance(expr, And)
+
+
 # --- Module and node-shape constraints -------------------------------
 
 


### PR DESCRIPTION
Closes #8. Closes #17.

The first of M2's feature work, and the first code that is not repairing M1. It takes the lexer's tokens and produces an AST.

## What this adds

**`src/historian/sql/ast.py`** — two separate frozen-dataclass hierarchies, statements and expressions, per spec §3. Every node carries a position so errors can point at the offending text.

**`src/historian/sql/parser.py`** — a hand-written recursive-descent / precedence-climbing parser. `parse(tokens: list[Token]) -> SelectStatement`, raising only `ParseError`, which carries a `Position` in the same shape as `LexError`.

It parses the whole non-`CASE` v1 expression grammar in one precedence table rather than only what M2's target query needs. The lexer already emits every token for it and `values.py` already implements the semantics, so the marginal cost was small — and precedence is far cheaper to get right once than to retrofit under a working parser.

`CASE` is deferred deliberately: it is an independent keyword-delimited primary form that does not interact with precedence, so building it later costs nothing. `GROUP BY`, `HAVING`, `ORDER BY`, `LIMIT`, `DISTINCT` and `JOIN` are M3 and later.

## The precedence table has two comparison tiers

This is the part most likely to be got wrong, because a single flat comparison tier looks right and parses every realistic query identically:

```
$ sqlite3 :memory: "select 3 = 0 < 3;"
0
```

A flat tier gives `(3 = 0) < 3` = `1`. The observed `0` means SQLite parses `3 = (0 < 3)` = `3 = 1` = `0`, so `<` `<=` `>` `>=` bind tighter than `=` `<>` `IS` `LIKE` `IN` `BETWEEN`. Verified during grooming and re-verified independently twice since.

Two more that were confirmed rather than assumed: `select 'a' || 1 + 1` gives `1`, matching `('a' || 1) + 1` and not `'a' || (1 + 1)` which gives `a2` — so `||` binds tighter than `+`. And `select 5 between 1 and 10 and 0` gives `0`, so `BETWEEN`'s own `AND` must not swallow the trailing predicate.

## The int64 boundary (#17)

SQLite integers are int64. A decimal literal that overflows becomes a real, so two distinct literals past the boundary collapse onto the same double:

```
$ sqlite3 :memory: "select typeof(9223372036854775807), typeof(9223372036854775808);"
integer|real
$ sqlite3 :memory: "select 9223372036854775808 = 9223372036854775809;"
1
```

Literal construction now parses the digit text as a Python `int` and falls back to `float` past `9223372036854775807`. The lexer never emits a signed `INTEGER` token — a leading `-` is always a separate `MINUS` — so the rule is one-directional.

**This does not touch the 2026-08-27 "numeric comparison is exact; no `float()`" decision.** That governs comparison inside `values.py`, which is untouched here and still has its 2^53 test passing. This conversion happens earlier, turning token text into a value, before anything reaches `values.py`. The two are different layers and `_docs/decisions.md` now says so explicitly.

`-9223372036854775808` is deliberately not special-cased. SQLite reports it as `integer` where negating an overflowed float gives a real, but 2^63 is exactly representable as a double so the two compare exactly equal, and this grammar has no `typeof` and no arithmetic to observe the difference by. The decisions entry records it as confirmed behaviour left for #12 to revisit when arithmetic exists.

## QA failed this once, and the fix is the interesting part

The first QA round passed all ~20 acceptance criteria and then failed the issue on a defect nobody had specified: **90 levels of nested parentheses raised a raw `RecursionError`**, which spec §5 forbids outright. Worse, `sqlite3` parses that same query and returns `1` — so historian was crashing on valid SQL, not merely mishandling absurd input.

The fix distinguishes two kinds of nesting, which is why one change could be generous where SQLite is generous and strict where it is strict:

- **Purely repetitive** nesting adds no meaning per level — `(((x)))` is just `x`, and so are `NOT NOT NOT x` and `---x`. These became loops. One iteration per token instead of one stack frame, bounded at 1000 to match `SQLITE_MAX_EXPR_DEPTH`.
- **Genuine** recursion — a sub-expression inside parens, an `IN`-list value, a function-call argument — still costs frames, and gets a separate limit of 50 at the single choke point they all pass through.

Two approaches were ruled out. Raising `sys.setrecursionlimit` relocates the cliff and trades a catchable exception for a possible hard interpreter crash. Catching `RecursionError` and re-raising it as a `ParseError` looks tidy but makes the effective limit depend on how much stack the *caller* already used, so the same query would parse or fail depending on where it was invoked from — which breaks the determinism `AGENTS.md` requires.

Measured boundaries, historian against a live `sqlite3` 3.51.0:

| shape | sqlite3 accepts to | historian accepts to |
|---|---|---|
| bare parens, `NOT` chains, unary chains | 93 | 1000 |
| genuine nesting, nested `IN`, function-call args | 31 | 50 |

historian is a superset in every shape. Beyond its limits it raises a clean `ParseError`; no `RecursionError` escapes at any depth, verified to 200,000.

## Verification

**QA verdict: PASS** — https://github.com/ionut-banu/historian/issues/8#issuecomment-5489923252
(the earlier FAIL, for the record: https://github.com/ionut-banu/historian/issues/8#issuecomment-5489455691)

`uv run pytest` gives **400 passed**, against 329 on `main`. 71 new tests; `git diff main..issue-8-ast-parser -- tests/` has **no removed lines**.

Because the fix rewrote parenthesis, `NOT` and unary parsing — code inside the precedence machinery that had already passed — QA re-derived the entire precedence table from scratch rather than assuming it survived, including `NOT a = 1` grouping as `NOT (a=1)`, `- -2`, unary minus against `||`, and left-associativity of `-` and `/`. No regression.

Determinism was checked directly: a depth-90 query gives the same result called from an empty stack and from 500 frames deep in unrelated recursion, and `sys.getrecursionlimit()` is untouched.

## Follow-ups filed, not fixed here

- **#24** — rejecting the six §1 non-goals by name (subqueries, CTEs, window functions, `UNION`, outer joins) rather than with a generic parse error. Split out of this issue during grooming: it is six independent detection strategies over words the lexer deliberately does not reserve, and it can never change a result, only an error message.
- **#25** — `SELECT path p FROM blame`, a bare alias without `AS`, which SQLite accepts and historian rejects. Found by QA, outside this issue's scope: spec §1 writes `[AS alias]` and the parser implements §1 faithfully. Whether the grammar or `AGENTS.md`'s SQLite-is-right rule wins for a syntactic narrowing is a real question and now has an issue instead of living in an implementation detail.
