### PR TITLE
Deterministic fixture repositories, and correct spec §4's recipe (#10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+
+# Built fixture repositories (tests/fixtures/build.py). Never
+# committed as binaries - see spec.md §4. No trailing slash: a
+# directory-only pattern only matches a path git can confirm is a
+# directory, which fails `git check-ignore` on a path that does not
+# exist on disk yet - and pytest may check this before anything has
+# built a fixture into it.
+tests/fixtures/_built

--- a/_docs/decisions.md
+++ b/_docs/decisions.md
@@ -379,3 +379,60 @@ in round 1 - only these four call sites change, and `(expr)`
 continues to produce no AST node of its own, so the loop-based
 paren handling is behaviourally identical to the recursive version
 it replaces.
+
+2026-09-01 - Fixture builds isolate from all ambient git
+configuration, not just the six GIT_* variables
+
+Issue #10 grooming found that spec §4's six GIT_AUTHOR_*/
+GIT_COMMITTER_* variables are necessary but not sufficient for
+byte-identical fixtures. Confirmed on this machine (git 2.50.1,
+Apple Git-155), with all six identical either way:
+`core.autocrlf=input` versus `core.autocrlf=false` produces
+different blob hashes for the same content, and a global
+`core.excludesFile` with a `*~` pattern silently drops a matching
+fixture file from `git add -A` with no error at all - no warning,
+no nonzero exit, just a fixture with one fewer file than intended.
+`commit.gpgsign=true` with no working signing key makes the commit
+fail outright, and `core.fileMode=false` changes what mode gets
+recorded at add time, not only what a later diff reports.
+
+`init.defaultBranch` is the sharpest case. Pointing
+`GIT_CONFIG_SYSTEM` at `/dev/null` alone does not suppress it on
+this platform, because Apple's Command Line Tools git ships its
+own hardcoded system-scope gitconfig, one directory below its
+install root, that `GIT_CONFIG_SYSTEM` does not point git away
+from - `GIT_CONFIG_NOSYSTEM=1` is required in addition. Verified
+directly: `GIT_CONFIG_SYSTEM=/dev/null` alone still resolves
+`init.defaultBranch` to "main" from Apple's file; adding
+`GIT_CONFIG_NOSYSTEM=1` falls back to git's real compiled-in
+default, "master".
+
+Considered enumerating and overriding every setting found to
+matter - the six env vars plus the four above - and rejected it,
+because a list like that is exactly the shape of thing that is
+missing an entry: the platform-specific system config above was
+found by testing, not by reading documentation, and a different
+contributor's machine can have another one nobody has hit yet. The
+fixture builder instead inherits nothing: `GIT_CONFIG_GLOBAL` and
+`GIT_CONFIG_SYSTEM` set to `/dev/null`, `GIT_CONFIG_NOSYSTEM=1`,
+every other ambient `GIT_*` environment variable stripped before
+any git subprocess runs, an explicit branch name passed to every
+`git init` rather than relying on any default, and the settings
+above still set explicitly as local repo config immediately
+afterward - defense in depth on top of the environment-level
+isolation, not instead of it. Proven, not just argued: the same
+fixture built under a hostile ambient config (autocrlf, gpgsign,
+excludesFile and defaultBranch all set adversarially) produces an
+identical HEAD, tree and full object set to a build with no
+ambient config present at all.
+
+spec.md §4 is edited in this commit. Its "so all of them are set
+explicitly," following the six variables, read as a complete
+recipe and was not one; per _docs/process.md, a spec edit that
+turns out wrong lands in the same commit as the decision that
+found it wrong. tiny and awkward now also pin their HEAD hash as
+an assertion, so a determinism regression fails immediately rather
+than waiting to be noticed downstream. `large` (spec §4's third
+fixture) is out of scope here - split into issue #27, since it
+gates no correctness test and needs its own build and caching
+decisions.

--- a/_docs/spec.md
+++ b/_docs/spec.md
@@ -568,17 +568,33 @@ Four layers, each answering a question the others cannot.
 Built by `tests/fixtures/build.py`, never committed as binaries.
 
 **They must be byte-identical on every machine and every run.** Git
-hashes derive from author, committer, timestamps and tree, so all of
-them are set explicitly:
+hashes derive from author, committer, timestamps and tree - but also
+from the ambient git configuration a build inherits. The six `GIT_*`
+variables below are necessary but not sufficient: on a real
+contributor machine, `core.autocrlf` alone was observed to change a
+blob's - and therefore a commit's - hash, and `init.defaultBranch`
+changes the branch name, independent of these six variables entirely.
 
 ```
 GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL, GIT_AUTHOR_DATE
 GIT_COMMITTER_NAME, GIT_COMMITTER_EMAIL, GIT_COMMITTER_DATE
 ```
 
-Without this, hashes differ per run, tests that assert on them are
-flaky, and nobody can reproduce a reported failure. It is the first
-thing to get right.
+So the builder isolates itself from all ambient git configuration
+rather than overriding known settings one at a time - a list of
+settings to override can always be missing an entry, while an
+environment that inherits nothing is closed by construction. It sets
+`GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` to `/dev/null` and
+`GIT_CONFIG_NOSYSTEM=1` before any git command runs (the third is
+required in addition to the second on at least one real platform:
+Apple's Command Line Tools git reads its own hardcoded system-scope
+config regardless of `GIT_CONFIG_SYSTEM`), always passes an explicit
+branch name to `git init` rather than relying on `init.defaultBranch`,
+and sets `core.autocrlf`, `core.fileMode`, `core.symlinks`,
+`core.ignoreCase`, `commit.gpgsign`, and `core.safecrlf` explicitly on
+the fixture repository as defense in depth. Without this, hashes and
+branch names differ per contributor machine, hash assertions are
+flaky, and no reported failure reproduces on anyone else's machine.
 
 Three fixtures:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+"""Shared pytest fixtures for historian's test suite.
+
+Exposes the `tiny` and `awkward` fixture repositories built by
+tests/fixtures/build.py (spec.md §4) as session-scoped pytest
+fixtures. Session scope: nothing in v1 mutates a fixture repo once
+built - every query historian runs is read-only, per §1's non-goals -
+so rebuilding per test would only cost time for no isolation benefit.
+
+`large` (spec.md §4) is tracked as its own issue (#27) and is not
+exposed here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fixtures.build import get_awkward_repo, get_tiny_repo
+
+
+@pytest.fixture(scope="session")
+def tiny_repo() -> Path:
+    return get_tiny_repo()
+
+
+@pytest.fixture(scope="session")
+def awkward_repo() -> Path:
+    return get_awkward_repo()

--- a/tests/fixtures/build.py
+++ b/tests/fixtures/build.py
@@ -552,3 +552,65 @@ def _verify_awkward(repo: Path) -> None:
             "awkward: the porcelain-lookalike line did not appear as a "
             "tab-prefixed content line in git blame --line-porcelain output"
         )
+
+
+# ---------------------------------------------------------------------------
+# Caching
+#
+# tiny and awkward are rebuilt exactly once per change to this file,
+# not once per test run - the whole suite is run on every engineer and
+# QA pass (_docs/process.md), and rebuilding a handful of commits is
+# proven idempotent above, so paying for it every time is pure waste.
+#
+# Built under a path inside tests/fixtures/ rather than a system temp
+# directory: that survives between runs (what makes caching worth
+# anything) and can be cd-ed into for manual debugging. Never
+# committed as binaries (spec.md §4) - see .gitignore.
+# ---------------------------------------------------------------------------
+
+CACHE_DIR = Path(__file__).parent / "_built"
+
+
+def _builder_digest() -> str:
+    """A digest of this file's own source, used to invalidate a cached
+    build when build.py itself changes - a version constant bumped by
+    hand can be forgotten; hashing the file it would have needed to
+    change to be forgotten cannot."""
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+
+def _cached(cache_dir: Path, name: str, builder) -> Path:
+    repo = cache_dir / name
+    digest_file = cache_dir / f"{name}.digest"
+    digest = _builder_digest()
+    if repo.exists() and digest_file.exists() and digest_file.read_text() == digest:
+        return repo
+    builder(repo)
+    digest_file.parent.mkdir(parents=True, exist_ok=True)
+    digest_file.write_text(digest)
+    return repo
+
+
+def get_tiny_repo(cache_dir: Path = CACHE_DIR) -> Path:
+    """Return the path to a built `tiny` repository, building (or
+    rebuilding, if build.py has changed since the cached one) it first
+    if necessary."""
+    return _cached(cache_dir, "tiny", build_tiny)
+
+
+def get_awkward_repo(cache_dir: Path = CACHE_DIR) -> Path:
+    """Return the path to a built `awkward` repository, building (or
+    rebuilding, if build.py has changed since the cached one) it first
+    if necessary."""
+    return _cached(cache_dir, "awkward", build_awkward)
+
+
+if __name__ == "__main__":
+    # Manual invocation for debugging: `uv run python -m tests.fixtures.build`
+    # (or `python tests/fixtures/build.py` from the repo root) builds
+    # both fixtures into the cache directory and prints where they
+    # landed, so they can be inspected or cd-ed into by hand.
+    for repo_name, getter in (("tiny", get_tiny_repo), ("awkward", get_awkward_repo)):
+        path = getter()
+        head = _run_git(path, ["rev-parse", "HEAD"]).strip()
+        print(f"{repo_name}: {path} (HEAD {head})")

--- a/tests/fixtures/build.py
+++ b/tests/fixtures/build.py
@@ -213,3 +213,146 @@ def _merge(repo: Path, branch: str, message: str, *, author: tuple[str, str], ti
     }
     _run_git(repo, ["merge", "--no-ff", "--quiet", "-m", message, branch], overrides)
     return _run_git(repo, ["rev-parse", "HEAD"]).strip()
+
+
+def _hex40_commit_hashes(porcelain_output: str) -> set[str]:
+    """The set of commit hashes appearing in a `git blame --line-porcelain`
+    header line (a 40-hex-digit line not starting with a tab)."""
+    hashes = set()
+    for line in porcelain_output.splitlines():
+        if line[:1] == "\t":
+            continue
+        head = line.split(" ", 1)[0]
+        if len(head) == 40 and all(c in "0123456789abcdef" for c in head):
+            hashes.add(head)
+    return hashes
+
+
+# ---------------------------------------------------------------------------
+# tiny
+#
+# "a handful of commits, two authors, a rename, a deletion, and a
+# merge" - spec.md §4. Exact content and the reasoning behind each
+# element is in the issue #10 grooming comment; the git graph built
+# here is the smallest one realizing every element without padding:
+#
+#   C1 (Ana)  add src/util.py, docs/todo.md
+#   C2 (Bo)   git mv src/util.py -> src/utils.py   (rename, no edit)
+#   C3 (Ana)  on branch "feature": add feature/thing.py
+#   C4 (Bo)   on main: remove docs/todo.md
+#   C5        merge feature into main (--no-ff, two parents: C4, C3)
+#
+# C3 and C4 touch different files, so the merge is conflict-free by
+# construction - if it weren't, `git merge` would exit nonzero and
+# _run_git would raise right there.
+# ---------------------------------------------------------------------------
+
+_TINY_ANA = ("Ana Petrova", "ana@example.com")
+_TINY_BO = ("Bo Lindqvist", "bo@example.com")
+
+# Filled in once, from this builder's own first deterministic build,
+# and then pinned: the strongest and cheapest regression check
+# available for byte-identical fixtures. See _docs/decisions.md,
+# 2026-09-01. Update in the same commit as any deliberate content
+# change to build_tiny.
+TINY_HEAD = "a088fde0619f0dd70e70eb47dad70cccf521f80e"
+
+
+def build_tiny(dest: Path) -> Path:
+    """Build the `tiny` fixture at dest, verify it, and return dest.
+
+    Raises FixtureError if the built repository does not match what
+    this function was told to build, including a determinism
+    regression against the pinned TINY_HEAD.
+    """
+    if dest.exists():
+        shutil.rmtree(dest)
+    _init_repo(dest, branch="main")
+    clock = _Clock()
+
+    (dest / "src").mkdir()
+    (dest / "src" / "util.py").write_text("def util():\n    return 42\n")
+    (dest / "docs").mkdir()
+    (dest / "docs" / "todo.md").write_text("- write blame\n")
+    _run_git(dest, ["add", "-A"])
+    _commit(dest, "Add util and todo", author=_TINY_ANA, timestamp=clock.tick())
+
+    _run_git(dest, ["mv", "src/util.py", "src/utils.py"])
+    _commit(dest, "Rename util.py to utils.py", author=_TINY_BO, timestamp=clock.tick())
+
+    _run_git(dest, ["checkout", "--quiet", "-b", "feature"])
+    (dest / "feature").mkdir()
+    (dest / "feature" / "thing.py").write_text("print('feature')\n")
+    _run_git(dest, ["add", "-A"])
+    _commit(dest, "Add feature/thing.py", author=_TINY_ANA, timestamp=clock.tick())
+
+    _run_git(dest, ["checkout", "--quiet", "main"])
+    _run_git(dest, ["rm", "--quiet", "docs/todo.md"])
+    _commit(dest, "Remove docs/todo.md", author=_TINY_BO, timestamp=clock.tick())
+
+    _merge(dest, "feature", "Merge feature into main", author=_TINY_ANA, timestamp=clock.tick())
+    _run_git(dest, ["branch", "-d", "feature"])
+
+    _verify_tiny(dest)
+
+    head = _run_git(dest, ["rev-parse", "HEAD"]).strip()
+    if head != TINY_HEAD:
+        raise FixtureError(
+            f"tiny: HEAD is {head}, pinned TINY_HEAD is {TINY_HEAD} - "
+            "this is a determinism regression, not a content change, "
+            "unless build_tiny was deliberately edited (update the "
+            "pinned constant in the same commit if so)"
+        )
+    return dest
+
+
+def _verify_tiny(repo: Path) -> None:
+    """Assert that repo matches what build_tiny is supposed to build.
+
+    Inspects only the finished repository through git itself - not any
+    bookkeeping from build_tiny - so it can also be pointed at a repo
+    that no longer matches (a mutated builder, a bad checkout) and
+    catch that directly, per spec §4: "the fixture builder asserts
+    what it built."
+    """
+    count = int(_run_git(repo, ["rev-list", "--count", "HEAD"]).strip())
+    if count != 5:
+        raise FixtureError(f"tiny: expected exactly 5 commits, found {count}")
+
+    merges = _run_git(repo, ["log", "--all", "--merges", "--format=%H"]).strip().splitlines()
+    merges = [m for m in merges if m]
+    if len(merges) != 1:
+        raise FixtureError(f"tiny: expected exactly one merge commit, found {len(merges)}")
+    parents = _run_git(repo, ["log", "-1", "--format=%P", merges[0]]).strip().split()
+    if len(parents) != 2:
+        raise FixtureError(f"tiny: merge commit {merges[0]} has {len(parents)} parents, expected 2")
+
+    identities = set(_run_git(repo, ["log", "--format=%an <%ae>"]).strip().splitlines())
+    if len(identities) != 2:
+        raise FixtureError(f"tiny: expected exactly 2 author identities, found {identities}")
+
+    head_paths = set(_run_git(repo, ["ls-tree", "-r", "--name-only", "HEAD"]).splitlines())
+    if "src/util.py" in head_paths:
+        raise FixtureError("tiny: src/util.py (pre-rename path) is still present at HEAD")
+    if "src/utils.py" not in head_paths:
+        raise FixtureError("tiny: src/utils.py (post-rename path) is missing from HEAD")
+    if "docs/todo.md" in head_paths:
+        raise FixtureError("tiny: docs/todo.md should have been deleted before HEAD")
+
+    deletion_history = _run_git(repo, ["log", "--all", "--format=%H", "--", "docs/todo.md"]).strip()
+    if not deletion_history:
+        raise FixtureError("tiny: docs/todo.md was never tracked - deletion needs prior history")
+
+    root_lines = _run_git(repo, ["rev-list", "--max-parents=0", "HEAD"]).strip().splitlines()
+    if len(root_lines) != 1:
+        raise FixtureError(f"tiny: expected exactly one root commit, found {len(root_lines)}")
+    root = root_lines[0]
+
+    porcelain = _run_git(repo, ["blame", "--line-porcelain", "src/utils.py"])
+    blamed = _hex40_commit_hashes(porcelain)
+    if blamed != {root}:
+        raise FixtureError(
+            "tiny: blame on src/utils.py at HEAD should attribute every "
+            f"line to the root commit {root} (the rename must not have "
+            f"changed content); got {blamed}"
+        )

--- a/tests/fixtures/build.py
+++ b/tests/fixtures/build.py
@@ -356,3 +356,199 @@ def _verify_tiny(repo: Path) -> None:
             f"line to the root commit {root} (the rename must not have "
             f"changed content); got {blamed}"
         )
+
+
+# ---------------------------------------------------------------------------
+# awkward
+#
+# "built to break things" - spec.md §4. One item per required property,
+# per the issue #10 grooming comment. Commit graph, smallest realizing
+# every item without padding:
+#
+#   C1 (Zoë)  add café.py, the space-and-quote path, empty.txt,
+#             binary.bin, no_newline.txt, phoenix.txt (original content)
+#   C2 (Sam)  edit café.py (append lines - exercises blame's compact
+#             header form on both C1's and C2's lines), delete
+#             phoenix.txt
+#   C3 (Sam)  recreate phoenix.txt with different content, empty
+#             commit message
+#
+# phoenix.txt's create/delete/recreate lifecycle is the one thing that
+# structurally needs three separate commits; everything else is
+# bundled into those three rather than padding the graph further.
+# ---------------------------------------------------------------------------
+
+_AWKWARD_ZOE = ("Zoë Müller", "zoe@example.com")
+_AWKWARD_SAM = ("Sam Lee", "sam@example.com")
+
+_AWKWARD_CAFE_PATH = "café.py"
+_AWKWARD_QUOTED_PATH = 'a "quoted" name.txt'
+_AWKWARD_EMPTY_PATH = "empty.txt"
+_AWKWARD_BINARY_PATH = "binary.bin"
+_AWKWARD_NO_NEWLINE_PATH = "no_newline.txt"
+_AWKWARD_PHOENIX_PATH = "phoenix.txt"
+
+AWKWARD_FILES = frozenset(
+    {
+        _AWKWARD_CAFE_PATH,
+        _AWKWARD_QUOTED_PATH,
+        _AWKWARD_EMPTY_PATH,
+        _AWKWARD_BINARY_PATH,
+        _AWKWARD_NO_NEWLINE_PATH,
+        _AWKWARD_PHOENIX_PATH,
+    }
+)
+
+# The porcelain-lookalike line: begins with exactly one of the real
+# `git blame --line-porcelain` header keywords followed by a space
+# ("author "), and is plain file content - not tab-prefixed in the
+# source blob. See the issue #10 grooming comment: this is precisely
+# the case a parser keying off `line.startswith("author ")` without
+# first checking for a leading tab misparses.
+AWKWARD_LOOKALIKE_LINE = "author nobody@nowhere.example claims to be a porcelain header but is not"
+
+_AWKWARD_CAFE_INITIAL = (
+    "# café.py - awkward fixture content\n"
+    "def greet():\n"
+    f'    return "café"\n'
+    f"{AWKWARD_LOOKALIKE_LINE}\n"
+)
+_AWKWARD_CAFE_APPENDED = "# appended by Sam\nprint(greet())\n"
+
+_AWKWARD_QUOTED_CONTENT = "content of the file with a space and a quote in its name\n"
+
+# Starts with a NUL byte, which git's binary-detection heuristic
+# samples from the first bytes of a blob - so this is unambiguously
+# binary-detected regardless of core.autocrlf. Fixed, not random: a
+# fixture must be byte-identical on every run.
+AWKWARD_BINARY_CONTENT = (
+    bytes([0x00, 0x01, 0x02, 0x03, 0xDE, 0xAD, 0xBE, 0xEF])
+    + b"not-a-real-image"
+    + bytes([0xFF, 0xFE, 0x00, 0x7F])
+)
+
+AWKWARD_NO_NEWLINE_CONTENT = b"first line\nsecond line\nthird line without a trailing newline"
+
+AWKWARD_PHOENIX_ORIGINAL = "phoenix: version one\n"
+AWKWARD_PHOENIX_RECREATED = "phoenix: reborn, version two\n"
+
+# Filled in once, from this builder's own first deterministic build,
+# and then pinned - see the note on TINY_HEAD above; the same applies
+# here.
+AWKWARD_HEAD = "c19c831743450c1c0bdf0a5d5096e2c25fa104f1"
+
+
+def build_awkward(dest: Path) -> Path:
+    """Build the `awkward` fixture at dest, verify it, and return dest.
+
+    Raises FixtureError if the built repository does not match what
+    this function was told to build, including a determinism
+    regression against the pinned AWKWARD_HEAD.
+    """
+    if dest.exists():
+        shutil.rmtree(dest)
+    _init_repo(dest, branch="main")
+    clock = _Clock()
+
+    (dest / _AWKWARD_CAFE_PATH).write_text(_AWKWARD_CAFE_INITIAL)
+    (dest / _AWKWARD_QUOTED_PATH).write_text(_AWKWARD_QUOTED_CONTENT)
+    (dest / _AWKWARD_EMPTY_PATH).write_bytes(b"")
+    (dest / _AWKWARD_BINARY_PATH).write_bytes(AWKWARD_BINARY_CONTENT)
+    (dest / _AWKWARD_NO_NEWLINE_PATH).write_bytes(AWKWARD_NO_NEWLINE_CONTENT)
+    (dest / _AWKWARD_PHOENIX_PATH).write_text(AWKWARD_PHOENIX_ORIGINAL)
+    _run_git(dest, ["add", "-A"])
+    _commit(dest, "Add the awkward fixture's initial files", author=_AWKWARD_ZOE, timestamp=clock.tick())
+
+    with (dest / _AWKWARD_CAFE_PATH).open("a") as f:
+        f.write(_AWKWARD_CAFE_APPENDED)
+    _run_git(dest, ["rm", "--quiet", _AWKWARD_PHOENIX_PATH])
+    _run_git(dest, ["add", "-A"])
+    _commit(dest, "Edit café.py, remove phoenix.txt", author=_AWKWARD_SAM, timestamp=clock.tick())
+
+    (dest / _AWKWARD_PHOENIX_PATH).write_text(AWKWARD_PHOENIX_RECREATED)
+    _run_git(dest, ["add", "-A"])
+    _commit(dest, "", author=_AWKWARD_SAM, timestamp=clock.tick(), allow_empty_message=True)
+
+    _verify_awkward(dest)
+
+    head = _run_git(dest, ["rev-parse", "HEAD"]).strip()
+    if head != AWKWARD_HEAD:
+        raise FixtureError(
+            f"awkward: HEAD is {head}, pinned AWKWARD_HEAD is {AWKWARD_HEAD} - "
+            "this is a determinism regression, not a content change, "
+            "unless build_awkward was deliberately edited (update the "
+            "pinned constant in the same commit if so)"
+        )
+    return dest
+
+
+def _verify_awkward(repo: Path) -> None:
+    """Assert that repo matches what build_awkward is supposed to build.
+
+    Inspects only the finished repository through git itself, per the
+    same reasoning as _verify_tiny above.
+    """
+    count = int(_run_git(repo, ["rev-list", "--count", "HEAD"]).strip())
+    if count != 3:
+        raise FixtureError(f"awkward: expected exactly 3 commits, found {count}")
+
+    identities = set(_run_git(repo, ["log", "--format=%an <%ae>"]).strip().splitlines())
+    if len(identities) != 2:
+        raise FixtureError(f"awkward: expected exactly 2 author identities, found {identities}")
+    if not any("Zoë Müller" in identity for identity in identities):
+        raise FixtureError(f"awkward: expected an author with a unicode name, found {identities}")
+
+    raw = _run_git(repo, ["ls-files", "-z"])
+    paths = {p for p in raw.split("\0") if p}
+    missing = AWKWARD_FILES - paths
+    if missing:
+        raise FixtureError(f"awkward: missing required file(s): {sorted(missing)}")
+    extra = paths - AWKWARD_FILES
+    if extra:
+        raise FixtureError(f"awkward: unexpected tracked file(s): {sorted(extra)}")
+
+    empty_size = int(_run_git(repo, ["cat-file", "-s", f"HEAD:{_AWKWARD_EMPTY_PATH}"]).strip())
+    if empty_size != 0:
+        raise FixtureError(f"awkward: {_AWKWARD_EMPTY_PATH} is not empty ({empty_size} bytes)")
+
+    binary_content = _run_git_bytes(repo, ["cat-file", "-p", f"HEAD:{_AWKWARD_BINARY_PATH}"])
+    if binary_content != AWKWARD_BINARY_CONTENT:
+        raise FixtureError(f"awkward: {_AWKWARD_BINARY_PATH}'s committed blob does not match its source bytes")
+
+    no_newline_content = _run_git_bytes(repo, ["cat-file", "-p", f"HEAD:{_AWKWARD_NO_NEWLINE_PATH}"])
+    if no_newline_content != AWKWARD_NO_NEWLINE_CONTENT:
+        raise FixtureError(f"awkward: {_AWKWARD_NO_NEWLINE_PATH}'s committed blob does not match its source bytes")
+    if no_newline_content.endswith(b"\n"):
+        raise FixtureError(f"awkward: {_AWKWARD_NO_NEWLINE_PATH} has a trailing newline, expected none")
+
+    phoenix_content = _run_git(repo, ["show", f"HEAD:{_AWKWARD_PHOENIX_PATH}"])
+    if phoenix_content != AWKWARD_PHOENIX_RECREATED:
+        raise FixtureError(
+            f"awkward: {_AWKWARD_PHOENIX_PATH} at HEAD is not the recreation "
+            f"(expected {AWKWARD_PHOENIX_RECREATED!r}, got {phoenix_content!r})"
+        )
+    deletions = _run_git(
+        repo, ["log", "--all", "--diff-filter=D", "--format=%H", "--", _AWKWARD_PHOENIX_PATH]
+    ).strip()
+    if not deletions:
+        raise FixtureError(f"awkward: {_AWKWARD_PHOENIX_PATH} was never deleted in history")
+
+    hashes = _run_git(repo, ["log", "--format=%H"]).strip().splitlines()
+    messages = [_run_git(repo, ["log", "-1", "--format=%B", h]).strip("\n") for h in hashes]
+    if "" not in messages:
+        raise FixtureError("awkward: expected one commit with an empty message")
+
+    cafe_source = _run_git(repo, ["cat-file", "-p", f"HEAD:{_AWKWARD_CAFE_PATH}"])
+    if AWKWARD_LOOKALIKE_LINE not in cafe_source.splitlines():
+        raise FixtureError(f"awkward: the porcelain-lookalike line is missing from {_AWKWARD_CAFE_PATH}")
+    for line in cafe_source.splitlines():
+        if line == AWKWARD_LOOKALIKE_LINE and line.startswith("\t"):
+            raise FixtureError("awkward: the porcelain-lookalike line must not start with a tab in the source")
+
+    porcelain = _run_git(repo, ["blame", "--line-porcelain", _AWKWARD_CAFE_PATH])
+    tab_content_lines = [line[1:] for line in porcelain.splitlines() if line.startswith("\t")]
+    if AWKWARD_LOOKALIKE_LINE not in tab_content_lines:
+        raise FixtureError(
+            "awkward: the porcelain-lookalike line did not appear as a "
+            "tab-prefixed content line in git blame --line-porcelain output"
+        )

--- a/tests/fixtures/build.py
+++ b/tests/fixtures/build.py
@@ -1,0 +1,215 @@
+"""Deterministic fixture repositories for historian's tests.
+
+Implements spec.md §4: fixture repositories that must be byte-identical
+on every machine and every run. See _docs/decisions.md, 2026-09-01,
+for what was found beyond the spec's original six GIT_* environment
+variables and why the fix is "inherit nothing" rather than "override
+the settings we know about."
+
+Only `tiny` and `awkward` are built here. `large` is tracked as its own
+issue (#27) and is deliberately not implemented in this module - see
+that issue for the isolation recipe restated for whoever picks it up.
+
+This module uses `subprocess` and touches git directly. Per AGENTS.md,
+that rule applies to src/historian/ (the parser, planner and executor);
+this is test infrastructure, so it is expected and lives outside
+src/historian/ entirely.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+
+class FixtureError(Exception):
+    """A fixture builder produced something that does not match what it
+    was told to build.
+
+    Spec §4: "The fixture builder asserts what it built. A fixture that
+    silently stops containing a merge commit takes a whole class of
+    tests with it." Raised by the builder itself, at build time, rather
+    than left to surface later as a confusing extraction or differential
+    test failure.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Isolation
+#
+# Git hashes derive from author, committer, timestamps and tree - but
+# also from whatever ambient git configuration the build inherits.
+# _docs/decisions.md (2026-09-01) records what this cost: core.autocrlf
+# alone changes a blob's hash, and a compiled-in system config (Apple's
+# Command Line Tools git ships one) survives GIT_CONFIG_SYSTEM=/dev/null
+# and needs GIT_CONFIG_NOSYSTEM=1 as well. So every git invocation here
+# goes through _isolated_env, which inherits nothing rather than
+# overriding a hand-maintained list of settings.
+# ---------------------------------------------------------------------------
+
+
+def _isolated_env(overrides: dict[str, str]) -> dict[str, str]:
+    """The environment for a git subprocess that inherits no ambient git
+    configuration at all.
+
+    Every ambient GIT_* variable is dropped, not just the well-known
+    config ones - a leftover GIT_AUTHOR_NAME or GIT_DIR from whatever
+    process launched us is exactly the kind of thing "inherit nothing"
+    is meant to rule out by construction, rather than by remembering to
+    override it too. `overrides` (the three isolation variables below,
+    plus the six GIT_AUTHOR_*/GIT_COMMITTER_* for a commit) are applied
+    last and always win.
+    """
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+    env["GIT_CONFIG_SYSTEM"] = "/dev/null"
+    # Necessary in addition to GIT_CONFIG_SYSTEM=/dev/null: Apple's
+    # Command Line Tools git reads its own hardcoded system-scope config
+    # (init.defaultBranch=main, credential.helper=osxkeychain) regardless
+    # of where GIT_CONFIG_SYSTEM points. Only NOSYSTEM suppresses it.
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env.update(overrides)
+    return env
+
+
+def _run_git(repo: Path, args: Sequence[str], overrides: dict[str, str] | None = None) -> str:
+    """Run a git command with cwd=repo under the isolated environment,
+    returning stdout. Raises RuntimeError with stderr on failure."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=_isolated_env(overrides or {}),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} (in {repo}) failed:\n{result.stderr}")
+    return result.stdout
+
+
+def _run_git_bytes(repo: Path, args: Sequence[str]) -> bytes:
+    """Like _run_git, but for commands whose output must be read as raw
+    bytes (a blob's content, which may be binary)."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=_isolated_env({}),
+        capture_output=True,
+        text=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} (in {repo}) failed:\n{result.stderr.decode(errors='replace')}")
+    return result.stdout
+
+
+# Local repo config set immediately after `git init`, as defense in
+# depth on top of the environment-level isolation above - not instead
+# of it. Chosen from the grooming's own list of settings that were each
+# demonstrated to change a hash or silently change what gets committed.
+_LOCAL_CONFIG = {
+    "core.autocrlf": "false",
+    "core.fileMode": "true",
+    "core.symlinks": "true",
+    "core.ignoreCase": "false",
+    "commit.gpgsign": "false",
+    "core.safecrlf": "false",
+    # Not itself a determinism hazard (git always escapes structurally
+    # special characters in a path, quotePath or not), but the awkward
+    # fixture's path containing a double quote is far easier to reason
+    # about in git's plain output with this off. -z output (used for
+    # every machine-parsed listing in this module) is unaffected either
+    # way; this is purely for anyone inspecting the fixture by hand.
+    "core.quotePath": "false",
+}
+
+
+def _init_repo(path: Path, *, branch: str) -> None:
+    """Create a fresh, isolated git repository at path with an explicit
+    initial branch name.
+
+    §4's finding made concrete: relying on init.defaultBranch's fallback
+    is not portable even with GIT_CONFIG_SYSTEM=/dev/null in place (see
+    _isolated_env above), so the branch name is always passed explicitly
+    rather than left to any default, isolated or not.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    _run_git(path, ["init", "--quiet", "-b", branch])
+    for key, value in _LOCAL_CONFIG.items():
+        _run_git(path, ["config", key, value])
+
+
+class _Clock:
+    """A deterministic, strictly increasing sequence of commit
+    timestamps, formatted for GIT_AUTHOR_DATE/GIT_COMMITTER_DATE.
+
+    Real wall-clock time is never used for a fixture commit: two builds
+    run seconds (or years) apart would otherwise disagree on every
+    commit's timestamp and therefore on every hash from that commit
+    onward. The starting point and step are arbitrary but fixed.
+    """
+
+    def __init__(self, start: int = 1_700_000_000, step: int = 3600):
+        self._next = start
+        self._step = step
+
+    def tick(self) -> str:
+        value = self._next
+        self._next += self._step
+        return f"{value} +0000"
+
+
+def _commit(
+    repo: Path,
+    message: str,
+    *,
+    author: tuple[str, str],
+    timestamp: str,
+    allow_empty_message: bool = False,
+) -> str:
+    """Commit the index with an explicit author/committer identity and
+    timestamp (spec §4's six GIT_* variables), returning the new HEAD.
+
+    Committer is always set identically to author: nothing in any
+    fixture needs them to differ, and keeping them equal keeps the
+    builder's surface area small.
+    """
+    name, email = author
+    overrides = {
+        "GIT_AUTHOR_NAME": name,
+        "GIT_AUTHOR_EMAIL": email,
+        "GIT_AUTHOR_DATE": timestamp,
+        "GIT_COMMITTER_NAME": name,
+        "GIT_COMMITTER_EMAIL": email,
+        "GIT_COMMITTER_DATE": timestamp,
+    }
+    args = ["commit", "--quiet", "-m", message]
+    if allow_empty_message:
+        args.append("--allow-empty-message")
+    _run_git(repo, args, overrides)
+    return _run_git(repo, ["rev-parse", "HEAD"]).strip()
+
+
+def _merge(repo: Path, branch: str, message: str, *, author: tuple[str, str], timestamp: str) -> str:
+    """Merge branch into the current branch with --no-ff, as an explicit
+    two-parent commit with the same deterministic identity as _commit.
+
+    If the merge cannot complete without conflict, `git merge` exits
+    nonzero and _run_git raises - which is the proof that a fixture's
+    two merge sides never touch the same file, rather than something
+    this function needs to check separately.
+    """
+    name, email = author
+    overrides = {
+        "GIT_AUTHOR_NAME": name,
+        "GIT_AUTHOR_EMAIL": email,
+        "GIT_AUTHOR_DATE": timestamp,
+        "GIT_COMMITTER_NAME": name,
+        "GIT_COMMITTER_EMAIL": email,
+        "GIT_COMMITTER_DATE": timestamp,
+    }
+    _run_git(repo, ["merge", "--no-ff", "--quiet", "-m", message, branch], overrides)
+    return _run_git(repo, ["rev-parse", "HEAD"]).strip()

--- a/tests/fixtures/test_build.py
+++ b/tests/fixtures/test_build.py
@@ -308,3 +308,203 @@ def test_verify_tiny_raises_when_a_required_file_is_dropped(tmp_path):
 
     with pytest.raises(build.FixtureError, match="utils.py"):
         build._verify_tiny(repo)
+
+
+# ---------------------------------------------------------------------------
+# awkward
+#
+# "built to break things" - spec.md §4. One item per required property,
+# per the issue #10 grooming comment.
+# ---------------------------------------------------------------------------
+
+
+def test_awkward_branch_is_main(tmp_path):
+    repo = build.build_awkward(tmp_path / "awkward")
+    branch = build._run_git(repo, ["branch", "--show-current"]).strip()
+    assert branch == "main"
+
+
+def test_awkward_commit_count_is_minimal(tmp_path):
+    repo = build.build_awkward(tmp_path / "awkward")
+    count = int(build._run_git(repo, ["rev-list", "--count", "HEAD"]).strip())
+    assert count == 3
+
+
+def test_awkward_exact_file_list(tmp_path):
+    repo = build.build_awkward(tmp_path / "awkward")
+    raw = build._run_git(repo, ["ls-files", "-z"])
+    paths = set(raw.split("\0")) - {""}
+    assert paths == build.AWKWARD_FILES
+
+
+def test_awkward_unicode_path_is_tracked(tmp_path):
+    repo = build.build_awkward(tmp_path / "awkward")
+    paths = set(build._run_git(repo, ["ls-files", "-z"]).split("\0")) - {""}
+    assert "café.py" in paths
+
+
+def test_awkward_space_and_quote_path_is_tracked(tmp_path):
+    repo = build.build_awkward(tmp_path / "awkward")
+    paths = set(build._run_git(repo, ["ls-files", "-z"]).split("\0")) - {""}
+    assert any(" " in p and '"' in p for p in paths)
+
+
+def test_awkward_unicode_author_name_appears(tmp_path):
+    repo = build.build_awkward(tmp_path / "awkward")
+    authors = build._run_git(repo, ["log", "--format=%an"])
+    assert "Zoë Müller" in authors
+
+
+def test_awkward_two_distinct_author_identities(tmp_path):
+    repo = build.build_awkward(tmp_path / "awkward")
+    identities = set(build._run_git(repo, ["log", "--format=%an <%ae>"]).strip().splitlines())
+    assert len(identities) == 2
+
+
+def test_awkward_empty_file_is_zero_bytes(tmp_path):
+    repo = build.build_awkward(tmp_path / "awkward")
+    size = int(build._run_git(repo, ["cat-file", "-s", "HEAD:empty.txt"]).strip())
+    assert size == 0
+
+
+def test_awkward_binary_blob_is_byte_identical_to_source(tmp_path):
+    repo = build.build_awkward(tmp_path / "awkward")
+    content = build._run_git_bytes(repo, ["cat-file", "-p", "HEAD:binary.bin"])
+    assert content == build.AWKWARD_BINARY_CONTENT
+    assert content[0:1] == b"\x00", "the NUL must be within the first bytes git samples"
+
+
+def test_awkward_no_trailing_newline_file_has_none(tmp_path):
+    repo = build.build_awkward(tmp_path / "awkward")
+    content = build._run_git_bytes(repo, ["cat-file", "-p", "HEAD:no_newline.txt"])
+    assert content == build.AWKWARD_NO_NEWLINE_CONTENT
+    assert not content.endswith(b"\n")
+
+
+def test_awkward_blame_on_no_trailing_newline_file_reports_final_line(tmp_path):
+    repo = build.build_awkward(tmp_path / "awkward")
+    porcelain = build._run_git(repo, ["blame", "--line-porcelain", "no_newline.txt"])
+    content_lines = [line[1:] for line in porcelain.splitlines() if line.startswith("\t")]
+    expected_last = build.AWKWARD_NO_NEWLINE_CONTENT.decode().splitlines()[-1]
+    assert content_lines[-1] == expected_last
+
+
+def test_awkward_phoenix_file_at_head_is_the_recreation_not_the_original(tmp_path):
+    repo = build.build_awkward(tmp_path / "awkward")
+    content = build._run_git(repo, ["show", "HEAD:phoenix.txt"])
+    assert content == build.AWKWARD_PHOENIX_RECREATED
+    assert content != build.AWKWARD_PHOENIX_ORIGINAL
+
+
+def test_awkward_phoenix_file_was_genuinely_deleted_in_history(tmp_path):
+    """Not a no-op restore: the file was actually absent from some
+    commit's tree, so a stale-cache bug reading ls-tree at HEAD only
+    would be exposed, per the grooming's "not a no-op restore" note."""
+    repo = build.build_awkward(tmp_path / "awkward")
+    deletions = build._run_git(
+        repo, ["log", "--all", "--diff-filter=D", "--format=%H", "--", "phoenix.txt"]
+    ).strip()
+    assert deletions != ""
+
+
+def test_awkward_has_an_empty_commit_message(tmp_path):
+    repo = build.build_awkward(tmp_path / "awkward")
+    hashes = build._run_git(repo, ["log", "--format=%H"]).strip().splitlines()
+    messages = [build._run_git(repo, ["log", "-1", "--format=%B", h]).strip("\n") for h in hashes]
+    assert "" in messages
+
+
+def test_awkward_porcelain_lookalike_line_is_tab_prefixed_content(tmp_path):
+    """Verified against real git blame --line-porcelain output: content
+    lines are tab-prefixed, header lines never are. The lookalike line
+    must appear as tab-prefixed content, and must not itself start with
+    a tab in the source blob."""
+    repo = build.build_awkward(tmp_path / "awkward")
+
+    source = build._run_git(repo, ["cat-file", "-p", "HEAD:café.py"])
+    assert build.AWKWARD_LOOKALIKE_LINE in source.splitlines()
+    for line in source.splitlines():
+        if line == build.AWKWARD_LOOKALIKE_LINE:
+            assert not line.startswith("\t")
+
+    porcelain = build._run_git(repo, ["blame", "--line-porcelain", "café.py"])
+    tab_content_lines = [line[1:] for line in porcelain.splitlines() if line.startswith("\t")]
+    assert build.AWKWARD_LOOKALIKE_LINE in tab_content_lines
+
+
+def test_awkward_naive_header_check_without_tab_falsely_matches_lookalike_line(tmp_path):
+    """The acceptance test for #11's extraction parser, run here against
+    the fixture directly: a parser that strips whitespace and then
+    checks header keyword prefixes - without checking for the leading
+    tab first - misidentifies our fixture's content line as a header.
+    A parser that checks for the tab first does not."""
+    repo = build.build_awkward(tmp_path / "awkward")
+    porcelain = build._run_git(repo, ["blame", "--line-porcelain", "café.py"])
+
+    naive_keywords = (
+        "author ", "author-mail ", "author-time ", "author-tz ",
+        "committer ", "committer-mail ", "committer-time ", "committer-tz ",
+        "summary ", "filename ", "previous ",
+    )
+    naive_false_positives = [
+        line for line in porcelain.splitlines()
+        if line.startswith("\t") and line.lstrip().startswith(naive_keywords)
+    ]
+    assert any(
+        build.AWKWARD_LOOKALIKE_LINE in line for line in naive_false_positives
+    ), "the fixture should make a tab-blind naive parser misfire on this line"
+
+    tab_correct_matches = [
+        line for line in porcelain.splitlines()
+        if (not line.startswith("\t")) and line.startswith(naive_keywords)
+    ]
+    assert not any(
+        build.AWKWARD_LOOKALIKE_LINE in line for line in tab_correct_matches
+    ), "a parser that checks for the tab first must not misidentify the content line as a header"
+
+
+def test_awkward_is_deterministic_across_independent_builds(tmp_path):
+    head_a = build.build_awkward(tmp_path / "a")
+    head_b = build.build_awkward(tmp_path / "b")
+    assert build._run_git(head_a, ["rev-parse", "HEAD"]) == build._run_git(head_b, ["rev-parse", "HEAD"])
+
+    objects_a = build._run_git(tmp_path / "a", ["rev-list", "--objects", "--all"])
+    objects_b = build._run_git(tmp_path / "b", ["rev-list", "--objects", "--all"])
+    assert objects_a == objects_b
+
+
+def test_awkward_head_matches_pinned_hash(tmp_path):
+    repo = build.build_awkward(tmp_path / "awkward")
+    assert build._run_git(repo, ["rev-parse", "HEAD"]).strip() == build.AWKWARD_HEAD
+
+
+def test_verify_awkward_raises_when_a_file_is_dropped(tmp_path):
+    """Simulates exactly the hostile-excludesFile hazard from §4: a
+    fixture with the right commit shape (3 commits, 2 authors) but
+    missing one required file, the way a silently-dropped file would
+    look. Built directly rather than through build_awkward, so the
+    commit count stays 3 and the file-presence check is what fires."""
+    repo = tmp_path / "missing-file"
+    build._init_repo(repo, branch="main")
+    clock = build._Clock()
+    zoe = ("Zoë Müller", "zoe@example.com")
+    sam = ("Sam Lee", "sam@example.com")
+
+    # Every awkward file except empty.txt.
+    (repo / "café.py").write_text(build._AWKWARD_CAFE_INITIAL)
+    (repo / 'a "quoted" name.txt').write_text(build._AWKWARD_QUOTED_CONTENT)
+    (repo / "binary.bin").write_bytes(build.AWKWARD_BINARY_CONTENT)
+    (repo / "no_newline.txt").write_bytes(build.AWKWARD_NO_NEWLINE_CONTENT)
+    (repo / "phoenix.txt").write_text(build.AWKWARD_PHOENIX_ORIGINAL)
+    build._run_git(repo, ["add", "-A"])
+    build._commit(repo, "initial", author=zoe, timestamp=clock.tick())
+
+    build._run_git(repo, ["rm", "--quiet", "phoenix.txt"])
+    build._commit(repo, "remove phoenix", author=sam, timestamp=clock.tick())
+
+    (repo / "phoenix.txt").write_text(build.AWKWARD_PHOENIX_RECREATED)
+    build._run_git(repo, ["add", "-A"])
+    build._commit(repo, "", author=sam, timestamp=clock.tick(), allow_empty_message=True)
+
+    with pytest.raises(build.FixtureError, match="empty.txt"):
+        build._verify_awkward(repo)

--- a/tests/fixtures/test_build.py
+++ b/tests/fixtures/test_build.py
@@ -508,3 +508,71 @@ def test_verify_awkward_raises_when_a_file_is_dropped(tmp_path):
 
     with pytest.raises(build.FixtureError, match="empty.txt"):
         build._verify_awkward(repo)
+
+
+# ---------------------------------------------------------------------------
+# Caching
+#
+# tiny and awkward are cheap enough to build but rebuilding them for
+# every test would still add up over a full run repeated on every
+# engineer and QA pass. Cached between runs; invalidated when build.py
+# itself changes, per the issue #10 grooming comment.
+# ---------------------------------------------------------------------------
+
+
+def test_get_tiny_repo_reuses_a_cached_build(tmp_path):
+    cache_dir = tmp_path / "cache"
+    repo = build.get_tiny_repo(cache_dir)
+    sentinel = repo / ".sentinel"
+    sentinel.write_text("still here")
+
+    repo_again = build.get_tiny_repo(cache_dir)
+
+    assert repo_again == repo
+    assert sentinel.exists(), "a cached build must not be rebuilt"
+
+
+def test_get_tiny_repo_rebuilds_when_the_builder_digest_is_stale(tmp_path):
+    cache_dir = tmp_path / "cache"
+    repo = build.get_tiny_repo(cache_dir)
+    sentinel = repo / ".sentinel"
+    sentinel.write_text("should be gone after rebuild")
+    (cache_dir / "tiny.digest").write_text("a stale digest, not build.py's real one")
+
+    build.get_tiny_repo(cache_dir)
+
+    assert not sentinel.exists(), "a stale builder digest must force a rebuild"
+
+
+def test_get_awkward_repo_reuses_a_cached_build(tmp_path):
+    cache_dir = tmp_path / "cache"
+    repo = build.get_awkward_repo(cache_dir)
+    sentinel = repo / ".sentinel"
+    sentinel.write_text("still here")
+
+    repo_again = build.get_awkward_repo(cache_dir)
+
+    assert repo_again == repo
+    assert sentinel.exists(), "a cached build must not be rebuilt"
+
+
+def test_default_cache_dir_is_gitignored():
+    """Fixtures are never committed as binaries (spec.md §4): the
+    default cache location must be excluded from the outer historian
+    repo, not merely a temp directory nobody happens to add."""
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        ["git", "check-ignore", "--quiet", str(build.CACHE_DIR)],
+        cwd=repo_root,
+    )
+    assert result.returncode == 0, f"{build.CACHE_DIR} is not gitignored"
+
+
+def test_tiny_repo_session_fixture_resolves_to_the_pinned_build(tiny_repo):
+    """Wiring test for the session-scoped fixture in tests/conftest.py
+    that #11 (and later issues) will consume."""
+    assert build._run_git(tiny_repo, ["rev-parse", "HEAD"]).strip() == build.TINY_HEAD
+
+
+def test_awkward_repo_session_fixture_resolves_to_the_pinned_build(awkward_repo):
+    assert build._run_git(awkward_repo, ["rev-parse", "HEAD"]).strip() == build.AWKWARD_HEAD

--- a/tests/fixtures/test_build.py
+++ b/tests/fixtures/test_build.py
@@ -165,3 +165,146 @@ def test_building_twice_is_byte_identical(tmp_path):
     objects_a = build._run_git(tmp_path / "a", ["rev-list", "--objects", "--all"])
     objects_b = build._run_git(tmp_path / "b", ["rev-list", "--objects", "--all"])
     assert objects_a == objects_b
+
+
+# ---------------------------------------------------------------------------
+# tiny
+#
+# A handful of commits, two authors, a rename, a deletion, and a merge.
+# See spec.md §4 and the issue #10 grooming comment for exact content.
+# ---------------------------------------------------------------------------
+
+
+def test_tiny_branch_is_main(tmp_path):
+    repo = build.build_tiny(tmp_path / "tiny")
+    branch = build._run_git(repo, ["branch", "--show-current"]).strip()
+    assert branch == "main"
+
+
+def test_tiny_commit_count_is_minimal(tmp_path):
+    """The builder asserts the exact count so a later accidental addition
+    or removal fails loudly, per the grooming comment."""
+    repo = build.build_tiny(tmp_path / "tiny")
+    count = int(build._run_git(repo, ["rev-list", "--count", "HEAD"]).strip())
+    assert count == 5
+
+
+def test_tiny_has_exactly_one_merge_commit_with_two_parents(tmp_path):
+    repo = build.build_tiny(tmp_path / "tiny")
+    merges = build._run_git(repo, ["log", "--all", "--merges", "--format=%H"]).strip().splitlines()
+    assert len(merges) == 1
+    parents = build._run_git(repo, ["log", "-1", "--format=%P", merges[0]]).strip().split()
+    assert len(parents) == 2
+
+
+def test_tiny_has_two_distinct_author_identities(tmp_path):
+    repo = build.build_tiny(tmp_path / "tiny")
+    identities = set(build._run_git(repo, ["log", "--format=%an <%ae>"]).strip().splitlines())
+    assert len(identities) == 2
+
+
+def test_tiny_rename_preserves_blame_attribution_at_head(tmp_path):
+    """A line predating the rename is still attributed by git blame on
+    the post-rename path at HEAD, to the original (root) commit - the
+    case this fixture requirement exists to exercise."""
+    repo = build.build_tiny(tmp_path / "tiny")
+
+    root = build._run_git(repo, ["rev-list", "--max-parents=0", "HEAD"]).strip()
+    assert "\n" not in root, "expected exactly one root commit"
+
+    porcelain = build._run_git(repo, ["blame", "--line-porcelain", "src/utils.py"])
+    commit_hashes = {
+        line.split(" ", 1)[0]
+        for line in porcelain.splitlines()
+        if len(line) >= 40 and all(c in "0123456789abcdef" for c in line[:40]) and line[:1] != "\t"
+    }
+    assert commit_hashes == {root}
+
+
+def test_tiny_old_path_absent_and_new_path_present_at_head(tmp_path):
+    repo = build.build_tiny(tmp_path / "tiny")
+    paths = build._run_git(repo, ["ls-tree", "-r", "--name-only", "HEAD"]).splitlines()
+    assert "src/util.py" not in paths
+    assert "src/utils.py" in paths
+
+
+def test_tiny_deleted_file_absent_from_head_but_existed_earlier(tmp_path):
+    repo = build.build_tiny(tmp_path / "tiny")
+    head_paths = build._run_git(repo, ["ls-tree", "-r", "--name-only", "HEAD"]).splitlines()
+    assert "docs/todo.md" not in head_paths
+
+    history = build._run_git(repo, ["log", "--all", "--format=%H", "--", "docs/todo.md"]).strip()
+    assert history != "", "docs/todo.md must have existed in some earlier commit"
+
+
+def test_tiny_is_deterministic_across_independent_builds(tmp_path):
+    head_a = build.build_tiny(tmp_path / "a")
+    head_b = build.build_tiny(tmp_path / "b")
+    assert build._run_git(head_a, ["rev-parse", "HEAD"]) == build._run_git(head_b, ["rev-parse", "HEAD"])
+
+    objects_a = build._run_git(tmp_path / "a", ["rev-list", "--objects", "--all"])
+    objects_b = build._run_git(tmp_path / "b", ["rev-list", "--objects", "--all"])
+    assert objects_a == objects_b
+
+
+def test_tiny_head_matches_pinned_hash(tmp_path):
+    """The strongest, cheapest regression check available: a determinism
+    regression fails this immediately, with no need to reproduce anyone
+    else's machine."""
+    repo = build.build_tiny(tmp_path / "tiny")
+    assert build._run_git(repo, ["rev-parse", "HEAD"]).strip() == build.TINY_HEAD
+
+
+def test_verify_tiny_raises_when_merge_commit_is_missing(tmp_path):
+    """The builder asserts what it built: if a fixture silently stopped
+    containing its merge commit, build-time verification must catch it,
+    not a downstream test. Simulated here by directly building a
+    mutated repo - same commit count, no merge - the way a broken
+    build_tiny might, and confirming _verify_tiny names the problem."""
+    repo = tmp_path / "no-merge"
+    build._init_repo(repo, branch="main")
+    clock = build._Clock()
+    for i in range(5):
+        (repo / f"file{i}.txt").write_text(f"content {i}\n")
+        build._run_git(repo, ["add", "-A"])
+        build._commit(repo, f"commit {i}", author=("Ana Petrova", "ana@example.com"), timestamp=clock.tick())
+
+    with pytest.raises(build.FixtureError, match="merge"):
+        build._verify_tiny(repo)
+
+
+def test_verify_tiny_raises_when_a_required_file_is_dropped(tmp_path):
+    """A different way a broken builder could silently fail: the
+    excludes-file hazard from §4 dropping a required fixture file. Here
+    a repo has the right shape - 5 commits, one 2-parent merge, two
+    authors - but src/utils.py never made it in, the way a hostile
+    excludesFile silently dropping a file would look. Verification
+    must say so rather than passing an incomplete fixture through."""
+    repo = tmp_path / "missing-file"
+    build._init_repo(repo, branch="main")
+    clock = build._Clock()
+    ana = ("Ana Petrova", "ana@example.com")
+    bo = ("Bo Lindqvist", "bo@example.com")
+
+    (repo / "f0.txt").write_text("zero\n")
+    build._run_git(repo, ["add", "-A"])
+    build._commit(repo, "commit 0", author=ana, timestamp=clock.tick())
+
+    (repo / "f1.txt").write_text("one\n")
+    build._run_git(repo, ["add", "-A"])
+    build._commit(repo, "commit 1", author=bo, timestamp=clock.tick())
+
+    build._run_git(repo, ["checkout", "--quiet", "-b", "feature"])
+    (repo / "f2.txt").write_text("two\n")
+    build._run_git(repo, ["add", "-A"])
+    build._commit(repo, "commit 2", author=ana, timestamp=clock.tick())
+
+    build._run_git(repo, ["checkout", "--quiet", "main"])
+    (repo / "f3.txt").write_text("three\n")
+    build._run_git(repo, ["add", "-A"])
+    build._commit(repo, "commit 3", author=bo, timestamp=clock.tick())
+
+    build._merge(repo, "feature", "merge", author=ana, timestamp=clock.tick())
+
+    with pytest.raises(build.FixtureError, match="utils.py"):
+        build._verify_tiny(repo)

--- a/tests/fixtures/test_build.py
+++ b/tests/fixtures/test_build.py
@@ -1,0 +1,167 @@
+"""Tests for tests/fixtures/build.py.
+
+Implements the isolation and determinism testing that spec.md §4 and
+_docs/decisions.md (2026-09-01, "Fixture builds isolate from all
+ambient git configuration") require: a fixture built twice must be
+byte-identical, and a fixture built under a hostile ambient git
+configuration must still be byte-identical to one built with no
+ambient configuration at all.
+
+This file tests the isolation *mechanism* directly, against small
+throwaway repositories, before the full tiny/awkward content-level
+tests exercise it through build_tiny/build_awkward.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from fixtures import build
+
+
+# ---------------------------------------------------------------------------
+# Isolation primitives
+# ---------------------------------------------------------------------------
+
+
+def _write_repo(path: Path, *, branch: str = "main") -> str:
+    """Build a minimal one-commit repo under full isolation, return HEAD."""
+    build._init_repo(path, branch=branch)
+    (path / "a.txt").write_text("hello\n")
+    build._run_git(path, ["add", "-A"])
+    return build._commit(
+        path,
+        "initial commit",
+        author=("Test Author", "author@example.com"),
+        timestamp=build._Clock().tick(),
+    )
+
+
+def test_isolated_env_strips_ambient_git_config_pointers(monkeypatch, tmp_path):
+    """A hostile GIT_CONFIG_GLOBAL in the parent process must not reach
+    the child git process: build._isolated_env always sets its own."""
+    hostile = tmp_path / "hostile-global.gitconfig"
+    hostile.write_text("[core]\n\tautocrlf = true\n")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(hostile))
+
+    env = build._isolated_env({})
+
+    assert env["GIT_CONFIG_GLOBAL"] == "/dev/null"
+    assert env["GIT_CONFIG_SYSTEM"] == "/dev/null"
+    assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+
+
+def test_isolated_env_strips_unrelated_ambient_git_vars(monkeypatch):
+    """Any other ambient GIT_* variable (e.g. a leftover GIT_AUTHOR_NAME
+    from a parent process) must not leak into the child either."""
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Someone Else")
+    monkeypatch.setenv("GIT_DIR", "/nonexistent")
+
+    env = build._isolated_env({})
+
+    assert "GIT_AUTHOR_NAME" not in env
+    assert "GIT_DIR" not in env
+
+
+def test_init_repo_uses_explicit_branch_not_ambient_default(tmp_path):
+    """git init must be told -b main explicitly; §4's finding is that
+    relying on init.defaultBranch is not portable."""
+    repo = tmp_path / "repo"
+    build._init_repo(repo, branch="main")
+
+    branch = build._run_git(repo, ["branch", "--show-current"]).strip()
+    assert branch == "main"
+
+
+def test_a_freshly_built_repo_has_no_global_or_system_config(tmp_path):
+    """git config --list --show-origin inside a fresh fixture repo shows
+    only local config the builder set - nothing from a global or system
+    scope. This is the direct acceptance test for isolation."""
+    repo = tmp_path / "repo"
+    _write_repo(repo)
+
+    origins = build._run_git(repo, ["config", "--list", "--show-origin"])
+    for line in origins.splitlines():
+        origin = line.split("\t", 1)[0]
+        assert origin.startswith("file:") and origin.endswith(".git/config"), (
+            f"config value leaked from a non-local scope: {line}"
+        )
+
+
+def test_hostile_ambient_config_does_not_change_the_commit_hash(monkeypatch, tmp_path):
+    """Building with a fake global config forcing core.autocrlf=true and
+    commit.gpgsign=true, and a fake system config forcing a different
+    default branch name, must produce the exact same HEAD as building
+    with no config files present at all."""
+    clean_head = _write_repo(tmp_path / "clean")
+
+    hostile_global = tmp_path / "hostile-global.gitconfig"
+    hostile_global.write_text("[core]\n\tautocrlf = true\n[commit]\n\tgpgsign = true\n")
+    hostile_system = tmp_path / "hostile-system.gitconfig"
+    hostile_system.write_text("[init]\n\tdefaultBranch = something-else\n")
+
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(hostile_global))
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(hostile_system))
+
+    hostile_head = _write_repo(tmp_path / "hostile")
+
+    assert hostile_head == clean_head
+
+
+def test_hostile_ambient_config_does_not_change_the_branch_name(monkeypatch, tmp_path):
+    hostile_system = tmp_path / "hostile-system.gitconfig"
+    hostile_system.write_text("[init]\n\tdefaultBranch = something-else\n")
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(hostile_system))
+
+    repo = tmp_path / "repo"
+    build._init_repo(repo, branch="main")
+
+    branch = build._run_git(repo, ["branch", "--show-current"]).strip()
+    assert branch == "main"
+
+
+def test_hostile_excludes_file_does_not_drop_a_fixture_file(monkeypatch, tmp_path):
+    """§4's finding: a global core.excludesFile matching a fixture path
+    can silently drop it from `git add -A` with no error. Isolation
+    must defeat this too."""
+    excludes = tmp_path / "hostile-excludes"
+    excludes.write_text("*.txt\n")
+    hostile_global = tmp_path / "hostile-global.gitconfig"
+    hostile_global.write_text(f"[core]\n\texcludesFile = {excludes}\n")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(hostile_global))
+
+    repo = tmp_path / "repo"
+    build._init_repo(repo, branch="main")
+    (repo / "keep-me.txt").write_text("must survive add -A\n")
+    build._run_git(repo, ["add", "-A"])
+
+    tracked = build._run_git(repo, ["ls-files"]).strip().splitlines()
+    assert "keep-me.txt" in tracked
+
+
+def test_hostile_gpgsign_does_not_break_the_commit(monkeypatch, tmp_path):
+    """A contributor with commit.gpgsign=true globally and no signing
+    key configured must not see fixture builds fail."""
+    hostile_global = tmp_path / "hostile-global.gitconfig"
+    hostile_global.write_text("[commit]\n\tgpgsign = true\n[gpg]\n\tprogram = /nonexistent-gpg\n")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(hostile_global))
+
+    # Must not raise.
+    _write_repo(tmp_path / "repo")
+
+
+def test_building_twice_is_byte_identical(tmp_path):
+    """The direct determinism test the issue calls for: build the same
+    fixture into two different empty directories and diff everything -
+    HEAD, tree, and the full object set."""
+    head_a = _write_repo(tmp_path / "a")
+    head_b = _write_repo(tmp_path / "b")
+
+    assert head_a == head_b
+
+    objects_a = build._run_git(tmp_path / "a", ["rev-list", "--objects", "--all"])
+    objects_b = build._run_git(tmp_path / "b", ["rev-list", "--objects", "--all"])
+    assert objects_a == objects_b


### PR DESCRIPTION
Closes #10.

Builds the git repositories every later test runs against. It is the gate on #11, the `blame` scan, which is the first code in the project allowed to touch git.

## The problem this issue is really about

Spec §4 required fixtures to be **byte-identical on every machine and every run**, because git hashes derive from author, committer, timestamps and tree — otherwise hash assertions are flaky and no reported failure reproduces for anyone else. §4 called it "the first thing to get right."

**§4's recipe was incomplete, and this PR corrects the spec as well as implementing it.** Setting the six `GIT_*` environment variables is necessary but not sufficient. With all six identical, ambient git configuration still changes the output:

```
core.autocrlf=input          commit=2909e5e  blob=e5c5c55
core.autocrlf=false          commit=58891d6  blob=cf9b2a8
init.defaultBranch=master    branch=master, hashes unchanged
```

This machine has `core.autocrlf=input` set globally, so fixtures built here would simply not match fixtures built by a contributor who has it unset — and every hash assertion would fail for exactly one of them. That is the failure §4 exists to prevent, arriving through a door §4 did not mention.

Two more from the same family, both found by building repositories rather than reading git's documentation:

- **`core.excludesFile` silently dropped a file.** A fixture file matching this machine's global `*~` pattern was simply absent, with no error and no warning.
- **`core.fileMode` changes what is recorded at `add` time**, not merely what later diffs report.

## The fix: inherit nothing, rather than override everything

A list of settings to override can always be missing an entry. An environment that inherits nothing is closed by construction. The builder sets `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` to `/dev/null`, sets `GIT_CONFIG_NOSYSTEM=1`, strips every other ambient `GIT_*` variable, and sets the settings above explicitly on the fixture repository as defence in depth.

**`GIT_CONFIG_NOSYSTEM=1` is not redundant with `GIT_CONFIG_SYSTEM=/dev/null`.** Apple's Command Line Tools git ships `/Library/Developer/CommandLineTools/usr/share/git-core/gitconfig` containing `init.defaultBranch = main`, and that file is still read when `GIT_CONFIG_SYSTEM` points at `/dev/null`:

```
GIT_CONFIG_SYSTEM=/dev/null   -> init.defaultBranch resolves to "main" from Apple's file
plus GIT_CONFIG_NOSYSTEM=1    -> no value; git falls back to "master"
```

Which produces a consequence worth stating plainly: **under correct isolation, git's default branch becomes `master`.** Isolation alone silently renames the branch. So the builder also passes an explicit `--initial-branch` rather than relying on any default — isolation and an explicit branch are both required, and neither is sufficient alone.

## Verification

**QA verdict: PASS** — https://github.com/ionut-banu/historian/issues/10#issuecomment-5490607393

`uv run pytest` gives **445 passed**, against 400 on `main`. 45 new tests, no removed lines.

**Pinned hashes.** `TINY_HEAD = a088fde0…` and `AWKWARD_HEAD = c19c8317…` are asserted constants, so any determinism regression fails loudly and immediately rather than on someone else's machine.

**The isolation was tested adversarially, three times independently** — by the engineer, by the orchestrator, and by QA, each constructing its own hostile configuration the others had not seen. Setting `core.autocrlf=true`, `core.fileMode=false`, `core.quotePath=true`, `commit.gpgsign=true`, `init.defaultBranch=definitely-not-main`, and a `core.excludesFile` matching `*.py` and `*.txt`, plus hostile identity variables, then building with the cache cleared:

```
tiny      HEAD=a088fde0619f  branch=main  matches pinned: True
awkward   HEAD=c19c83174345  branch=main  matches pinned: True
```

That `excludesFile` alone would have swallowed most of the fixture content.

**The builder's self-verification is real.** §4 warns that "a fixture that silently stops containing a merge commit takes a whole class of tests with it." QA established this by mutating a copy of the builder to drop the merge, and got `FixtureError: tiny: expected exactly 5 commits, found 4` at build time rather than a quietly broken repository. Every property is re-derived from git itself rather than from build-time bookkeeping.

**The awkward fixture's porcelain-lookalike line genuinely works.** It exists to break #11's `git blame --line-porcelain` parser, and QA confirmed against real porcelain output that it fools a naive strip-then-match parser while a tab-aware one handles it — rather than merely resembling porcelain.

## Fixture contents

**tiny** — two authors, a rename with attribution surviving it, a deletion genuinely absent at `HEAD`, exactly one two-parent merge. Small enough to reason about by hand.

**awkward** — unicode in a path and an author name, a path with both a space and a quote, an empty file, a NUL-containing binary file, a file with no trailing newline, a file deleted and recreated with different content, an empty commit message, and the porcelain-lookalike line.

All verified by interrogating git directly, not by reading `build.py`.

## Scope and follow-ups

**#27** — the `large` fixture (hundreds of commits, benchmarks only per §4) was split out during grooming and targets M4, where the "12 of 4,013 paths" pushdown demo first needs it. Building it on every `pytest` run until then is pure cost.

**One known limitation, deliberately not fixed.** The awkward fixture's unicode path relies on the path bytes round-tripping through the filesystem. APFS is byte-preserving; an HFS+ volume normalising to NFD would store different bytes for the same characters and produce a different tree hash. QA established this would be caught **loudly** by the builder's exact-path-set verification rather than silently changing a hash, so the failure mode is a clear error on an unusual filesystem rather than a mystery. Not worth pre-emptive work; recorded here so it is recognisable if it ever appears.
