### PR TITLE
The blame scan and its extraction tests (#11, #20)

### DIFF
--- a/_docs/decisions.md
+++ b/_docs/decisions.md
@@ -436,3 +436,38 @@ than waiting to be noticed downstream. `large` (spec §4's third
 fixture) is out of scope here - split into issue #27, since it
 gates no correctness test and needs its own build and caching
 decisions.
+
+2026-09-01 - Git bytes are decoded as UTF-8 with errors="replace",
+not surrogateescape
+
+Settled while grooming #11, answering the question #20 asked.
+Confirmed directly:
+
+    surrogateescape  ->  UnicodeEncodeError: surrogates not allowed
+    replace          ->  inserts, round-trips equal
+
+surrogateescape produces a Python str that Python's own sqlite3
+module cannot insert at all. Since §1 makes SQLite the definition
+of correct, and M3's differential harness loads every scanned row
+into SQLite, that choice would have made the oracle itself
+unusable - the failure would have surfaced in M3 as a harness
+crash, not as a decoding bug, long after #11's context was gone.
+`errors="replace"` inserts cleanly and round-trips equal, and is
+tables/blame.py's `_decode`, used for both `path` and a blamed
+`line`.
+
+Consequence for values.py: `errors="replace"` can never produce a
+lone surrogate, which is what makes that module's UTF-8-ordering
+assumption true. Not a general fact about Unicode - false for a
+lone surrogate, which is exactly what #20 asked about - but a
+narrow one about every string this decode call can ever produce.
+tests/test_values.py's docstring on
+test_text_comparison_is_bytewise_for_non_ascii was corrected in
+this same branch to state the narrow claim instead of the general
+one.
+
+Known gap, recorded rather than fixed: neither `tiny` nor
+`awkward` exercises non-UTF-8 bytes in a *path*, only in file
+content (`awkward`'s binary.bin). It is the same decode call
+either way, so this is a coverage remark, not an open design
+question.

--- a/_docs/spec.md
+++ b/_docs/spec.md
@@ -211,11 +211,15 @@ Pushdown:
 `author_name`, `commit_hash`, `authored_at`, and `line_no` cannot push
 down: a line's author is unknown until the file has been blamed.
 
-Implementation: `git ls-tree -r HEAD --name-only` to enumerate
+Implementation: `git ls-tree -rz HEAD --name-only` to enumerate
 candidate paths, filtered by pushed path predicates, then
-`git blame --line-porcelain` per surviving file, parsed into rows and
-streamed. Blame is always at `HEAD` in v1; blaming at an arbitrary
-revision is deferred.
+`git blame --line-porcelain` per surviving file, parsed into rows
+and streamed. The `-z` form is required: plain `--name-only`
+quote-escapes any path containing a space or a double quote, and
+`git blame`'s own `filename` header re-quotes the same way with no
+unquoted form to parse back out, so `path` always comes from the
+enumeration instead. Blame is always at `HEAD` in v1; blaming at
+an arbitrary revision is deferred.
 
 Shelling out to `git blame` is deliberate. Rename detection and merge
 handling are a month of work in a domain nobody is evaluating, and the

--- a/src/historian/schema.py
+++ b/src/historian/schema.py
@@ -1,0 +1,100 @@
+"""``Schema`` and ``Row``: the generic shapes every operator's output
+takes.
+
+Introduced by issue #11, not #9. #9's filed body originally assumed the
+binder would own these ("the binder probably owns Schema, Row and the
+table catalog"), but #11 (a scan) is groomed to land first, and per
+`_docs/spec.md` §3 "the schema lives on the operator, not in the row" -
+a scan cannot produce or describe rows without these existing. #9
+imports `blame`'s `Schema` instance from `historian.tables.blame` rather
+than redefining it; the multi-table catalog (table name -> `Schema`,
+used for `FROM`-clause resolution) remains #9's job, not this module's.
+
+A natural sibling of ``values.py``: foundational, imported everywhere,
+and importing nothing from ``sql/``, ``plan/`` or ``exec/`` in either
+direction - a scan needs a `Schema` to describe its rows, and nothing
+above the scan layer needs to be defined for that to be possible.
+
+Not in this module
+-------------------
+
+**The table catalog** (name -> `Schema`, `FROM`-clause resolution) -
+#9. **Column affinity** (converting a literal to a column's declared
+type for comparison) - `exec/expression.py`, per `values.py`'s own
+"Not in this module" section; `Column.type` here is the declared type
+affinity resolves *against*, not the affinity logic itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from .values import Value
+
+__all__ = ["Column", "ColumnType", "Row", "Schema"]
+
+#: A row is a plain tuple of values, one per column, in schema order.
+#: Per spec §3: "The schema lives on the operator, not in the row, so
+#: rows stay cheap and column references resolve to integer offsets at
+#: bind time rather than by name at runtime." A ``Row`` therefore
+#: carries no column names or types of its own - always read it
+#: alongside the ``Schema`` that describes it.
+Row = tuple[Value, ...]
+
+
+class ColumnType(Enum):
+    """The three SQLite storage-class affinities `_docs/spec.md` §2
+    restricts every table's declared column types to.
+
+    Each member's value is the affinity's own SQLite spelling
+    (``"TEXT"``, not an arbitrary label), because a declared column
+    type exists to be compared against or fed to SQLite - the
+    differential harness's `CREATE TABLE` (M3) and the affinity
+    coercion in `exec/expression.py` both want the SQLite keyword
+    itself, not a translation step back to one.
+    """
+
+    TEXT = "TEXT"
+    INTEGER = "INTEGER"
+    REAL = "REAL"
+
+
+@dataclass(frozen=True)
+class Column:
+    """One column of a `Schema`: its name and declared type."""
+
+    name: str
+    type: ColumnType
+
+
+@dataclass(frozen=True)
+class Schema:
+    """The ordered column list an operator's rows conform to.
+
+    Frozen and order-preserving: a `Row`'s values line up with
+    `columns` positionally, so the order is part of the schema's
+    identity, not an incidental detail of how it was built.
+    """
+
+    columns: tuple[Column, ...]
+
+    def index_of(self, name: str) -> int:
+        """The 0-based position of the column named *name*.
+
+        This is the "integer offsets at bind time" spec §3 describes -
+        the mechanism a future binder/`exec/expression.py` uses to turn
+        a `ColumnRef` into a position in a `Row`, looked up once rather
+        than by name on every row. Raises ``KeyError`` for an unknown
+        name; there is no silent fallback, the same way a dict raises
+        for a missing key rather than returning something guessed.
+        """
+        for position, column in enumerate(self.columns):
+            if column.name == name:
+                return position
+        raise KeyError(name)
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        """The column names in schema order, e.g. for a header row."""
+        return tuple(column.name for column in self.columns)

--- a/src/historian/tables/blame.py
+++ b/src/historian/tables/blame.py
@@ -1,0 +1,272 @@
+"""The `blame` scan: `_docs/spec.md` §2, phase 1.
+
+One row per line of code alive at `HEAD`. This is the first module in
+`src/` allowed to touch git - per `AGENTS.md`, only scan operators do,
+and this is one. `subprocess` appears nowhere else under `src/`.
+
+Two commands, per spec §2's "Implementation"
+----------------------------------------------
+
+1. ``git ls-tree -rz HEAD --name-only`` enumerates every path tracked
+   at `HEAD`. **Not** the unqualified ``--name-only`` spec §2's prose
+   shows: verified during grooming that plain `ls-tree` quote-and-
+   backslash-escapes any path containing a space or a double quote
+   (git's own C-style path quoting, on regardless of `core.quotePath`),
+   which corrupts the `awkward` fixture's ``a "quoted" name.txt``. The
+   ``-z``, NUL-terminated form prints the raw bytes.
+2. ``git blame --line-porcelain HEAD -- <path>`` per surviving path,
+   parsed into rows. ``--line-porcelain`` (not plain ``--porcelain``)
+   repeats the full commit header on *every* line rather than
+   abbreviating repeats for consecutive same-commit lines - the
+   property that makes a stateless, per-line parse correct without
+   tracking "the last header seen".
+
+`blame.path` is never read back out of the porcelain output's own
+``filename`` header line. That header re-quotes exactly the way
+`ls-tree` does (``filename "a \\"quoted\\" name.txt"``), with no
+unquoted form - verified during grooming. Every row's `path` instead
+comes from the enumeration in (1), which the scan already knows it
+invoked `git blame` on.
+
+Decoding
+--------
+
+Git bytes (`path` and a blamed `line`) are decoded as UTF-8 with
+``errors="replace"``, not ``surrogateescape``. This closes #20:
+`surrogateescape` produces a Python `str` that Python's own `sqlite3`
+module cannot insert at all (`UnicodeEncodeError: surrogates not
+allowed`), which would break M3's differential harness outright, since
+its SQLite side is loaded from these same extracted rows
+(`_docs/decisions.md`, 2026-08-24). `errors="replace"` inserts and
+round-trips cleanly, and - because it never produces a lone surrogate -
+keeps `values.py`'s bytewise-text-ordering assumption true in practice
+for every value historian actually produces. The same decode call
+handles both `path` and `line`; see the module-level `_decode`.
+
+A newline byte (``0x0A``) is never consumed as part of an invalid
+multi-byte sequence's replacement: verified directly that
+``b"\\xff\\n\\xfe".decode("utf-8", errors="replace")`` still splits on
+that ``\\n``. So the whole `git blame` byte stream is decoded once and
+split on ``"\\n"``, rather than decoding line by line - both give the
+same result, and decoding once is simpler.
+
+Parsing a porcelain block: leading tab first, never a keyword match
+---------------------------------------------------------------------
+
+A content line is identified by a leading tab character on that line,
+checked *before* anything else - never by testing whether the line's
+text looks like a known header keyword. The `awkward` fixture's
+`café.py` contains a line of file content that is itself the text
+``"author nobody@nowhere.example claims to be a porcelain header but is
+not"`` - verified to genuinely fool a parser that strips the line and
+then matches it against known header prefixes, because after stripping
+its leading tab the line *is* indistinguishable from a real ``author``
+header. Checking for the tab first, and only ever stripping that one
+leading character (never a general `.strip()`), is what tells them
+apart. `tests/extraction/test_blame.py` has its own, independently
+written parser that proves this the same way, on the same fixture.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Iterator, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..schema import Column, ColumnType, Row, Schema
+
+__all__ = ["BLAME_SCHEMA", "BlameScan", "blame_paths", "list_paths"]
+
+#: `blame`'s seven columns (spec §2), in column order. Imported by #9
+#: (the table catalog) and #12 (the `Scan` operator) rather than either
+#: redefining it - see the grooming decision recorded on both issues.
+BLAME_SCHEMA = Schema(
+    columns=(
+        Column("path", ColumnType.TEXT),
+        Column("line_no", ColumnType.INTEGER),
+        Column("line", ColumnType.TEXT),
+        Column("commit_hash", ColumnType.TEXT),
+        Column("author_name", ColumnType.TEXT),
+        Column("author_email", ColumnType.TEXT),
+        Column("authored_at", ColumnType.TEXT),
+    )
+)
+
+
+def _decode(data: bytes) -> str:
+    """Decode raw git bytes as UTF-8 with `errors="replace"` - the
+    decoding policy settled by grooming (#20) for both `path` and
+    `line`. See the module docstring for why."""
+    return data.decode("utf-8", errors="replace")
+
+
+def _run_git_bytes(repo: Path, args: Sequence[str]) -> bytes:
+    """Run a git command with cwd=repo, returning raw stdout bytes.
+
+    Always an explicit argv list, never `shell=True` and never a
+    formatted command string - the `awkward` fixture's quoted-and-
+    spaced path is a real shell-injection-shaped hazard here, matching
+    the convention `tests/fixtures/build.py` already established.
+    Output is read as bytes, not decoded by `subprocess` itself
+    (`text=False`, the default): a blamed line's content can be
+    invalid UTF-8 (`binary.bin`), and decoding is this module's own
+    policy (`_decode`), not the standard library's default of
+    surrogate-escaping or raising.
+    """
+    result = subprocess.run(["git", *args], cwd=repo, capture_output=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} (in {repo}) failed:\n{_decode(result.stderr)}"
+        )
+    return result.stdout
+
+
+def list_paths(repo: Path) -> list[str]:
+    """Enumerate every path tracked at `HEAD`, via
+    ``git ls-tree -rz HEAD --name-only`` (see the module docstring for
+    why ``-z`` and not the unqualified form)."""
+    raw = _run_git_bytes(repo, ["ls-tree", "-rz", "HEAD", "--name-only"])
+    return [_decode(chunk) for chunk in raw.split(b"\0") if chunk]
+
+
+def _authored_at(unix_time: int) -> str:
+    """ISO-8601 UTC of the form ``YYYY-MM-DDTHH:MM:SSZ``, from the
+    porcelain ``author-time`` field (a Unix timestamp, already UTC).
+
+    Deliberately not `author-tz`: `author-tz` is a display offset, and
+    using it would need this scan to interpret it correctly for
+    `authored_at` to be right - `author-time` alone is enough, and
+    keeps `authored_at > '2026-01-01'` behaving identically in
+    historian and SQLite with no conversion layer (spec §2).
+    """
+    return datetime.fromtimestamp(unix_time, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_porcelain(text: str, path: str) -> Iterator[Row]:
+    """Parse one file's ``git blame --line-porcelain`` output (already
+    decoded) into rows, in file order.
+
+    Stateful and positional, not keyword-matching: each record starts
+    with a commit-info line (``<hash> <orig-line> <final-line>
+    [<count>]``, never tab-prefixed), is followed by header fields
+    (``author ...``, ``author-mail ...``, ``author-time ...`` and
+    others this scan does not need), and ends at the first line that
+    starts with a tab - which is the content line, and the *only* thing
+    a leading tab is ever checked for. See the module docstring for why
+    this order of checks matters for the `awkward` fixture.
+
+    `path` is never read from the porcelain ``filename`` field; it is
+    the path the caller already invoked `git blame` on.
+    """
+    lines = text.split("\n")
+    index = 0
+    total = len(lines)
+    while index < total:
+        header = lines[index]
+        if header == "":
+            # A trailing blank line from the final "\n" before EOF (or
+            # the whole file being empty, in which case this loop never
+            # starts at all - `_run_git_bytes` returns b"" for
+            # `empty.txt` and `text.split("\n")` is then `[""]`).
+            index += 1
+            continue
+
+        commit_hash, _orig_line, final_line, *_count = header.split(" ")
+        line_no = int(final_line)
+        index += 1
+
+        author_name: str | None = None
+        author_email: str | None = None
+        author_time: int | None = None
+        while True:
+            field = lines[index]
+            if field.startswith("\t"):
+                content = field[1:]
+                index += 1
+                break
+            if field.startswith("author-mail "):
+                author_email = field[len("author-mail ") :].strip("<>")
+            elif field.startswith("author-time "):
+                author_time = int(field[len("author-time ") :])
+            elif field.startswith("author "):
+                author_name = field[len("author ") :]
+            index += 1
+
+        assert author_name is not None
+        assert author_email is not None
+        assert author_time is not None
+        yield (
+            path,
+            line_no,
+            content,
+            commit_hash,
+            author_name,
+            author_email,
+            _authored_at(author_time),
+        )
+
+
+def _blame_file(repo: Path, path: str) -> Iterator[Row]:
+    """Blame one file at `HEAD`, yielding its rows in line order."""
+    raw = _run_git_bytes(repo, ["blame", "--line-porcelain", "HEAD", "--", path])
+    yield from _parse_porcelain(_decode(raw), path)
+
+
+def blame_paths(repo: Path, paths: Sequence[str]) -> Iterator[Row]:
+    """Blame each of `paths` at `HEAD` in `repo`, in the given order,
+    streaming rows.
+
+    Split out from `BlameScan.scan` so "zero paths in, zero rows out"
+    is testable directly, with no repository required: given an empty
+    `paths`, this loop body never runs, so no git command is ever
+    invoked - `repo` need not even exist.
+    """
+    for path in paths:
+        yield from _blame_file(repo, path)
+
+
+class BlameScan:
+    """The `blame` table's scan operator (spec §2, phase 1; §3's scan
+    interface).
+
+    Blame is always at `HEAD` in v1 (spec §2); blaming at another
+    revision is out of scope. Rename detection and merge handling are
+    left entirely to `git blame` itself - reimplementing either is a
+    month of work in a domain nobody is evaluating (spec §2), so this
+    class shells out and parses, and does nothing else.
+    """
+
+    #: The schema every row from `scan()` conforms to.
+    schema = BLAME_SCHEMA
+
+    def __init__(self, repo: Path):
+        self._repo = Path(repo)
+
+    def capabilities(self) -> set[str]:
+        """Which pushdown kinds this scan can use.
+
+        Always empty. `blame`'s path/author/time pushdown (spec §2's
+        table) is M4's job (#13/#14, "Scan capability negotiation and
+        predicate splitting") - this issue shapes `capabilities()`'s
+        and `scan()`'s call convention per §2 without inventing the
+        `PushdownKind`/`Predicate` types that negotiation needs, per
+        the grooming decision on #11. An empty set here is not a
+        placeholder pending that work; it is simply true today - this
+        scan does not yet know how to use a predicate to do less work.
+        """
+        return set()
+
+    def scan(self, pushed: Sequence[object] = ()) -> Iterator[Row]:
+        """Yield every `blame` row at `HEAD`, streamed file by file.
+
+        `pushed` is accepted per §2's ``scan(pushed)`` call convention
+        and is provably ignored: `capabilities()` returns an empty set,
+        so a future planner (#13) never has anything accepted to pass
+        here, and this method does not inspect `pushed`'s contents at
+        all - every path `list_paths` reports is always blamed,
+        whatever `pushed` is. Rows are streamed (a generator), never
+        materialized as a list, matching spec §1's "no materialized
+        copy" and §2's phase-1 implementation note.
+        """
+        yield from blame_paths(self._repo, list_paths(self._repo))

--- a/tests/extraction/test_blame.py
+++ b/tests/extraction/test_blame.py
@@ -1,0 +1,379 @@
+"""Extraction tests for the `blame` scan (`_docs/spec.md` §4, §2).
+
+The extraction layer proves the git *data* is right, not that the SQL
+is - both a future differential test's historian side and its SQLite
+side would read the same extracted rows, so a wrong `authored_at`
+would be wrong on both and invisible there (spec §4). So `blame` rows
+are checked here against `git blame --line-porcelain` itself, on the
+`tiny` and `awkward` fixtures (`tests/conftest.py`, built by
+`tests/fixtures/build.py`).
+
+Independent oracle, on purpose
+-------------------------------
+
+`_oracle_blame` below parses `git blame --line-porcelain` output using
+a *different* algorithm from `historian.tables.blame`'s own parser: it
+positively matches a commit-info header line with a regular expression
+and accumulates header fields into a dict, rather than the production
+parser's linear state machine that ends a record at the first
+tab-prefixed line it meets. It calls nothing from
+`historian.tables.blame` except the `BLAME_SCHEMA` column order (a
+schema, not parsing logic). If the production parser and this one
+agreed by sharing a bug, this test would not catch it; deliberately not
+sharing code is what makes that not the case. `café.py`'s
+porcelain-lookalike line - real content whose text, after stripping a
+tab, reads exactly like a genuine `author` header - is what a shared
+bug would most plausibly be, so `test_lookalike_line_...` below is the
+test that most directly earns this independence.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fixtures.build import AWKWARD_HEAD, AWKWARD_LOOKALIKE_LINE
+
+from historian.schema import Row
+from historian.tables import blame
+from historian.tables.blame import BLAME_SCHEMA, BlameScan
+
+# --- The independent oracle ------------------------------------------------
+
+_PATH_IDX = BLAME_SCHEMA.index_of("path")
+_LINE_NO_IDX = BLAME_SCHEMA.index_of("line_no")
+_LINE_IDX = BLAME_SCHEMA.index_of("line")
+_COMMIT_HASH_IDX = BLAME_SCHEMA.index_of("commit_hash")
+_AUTHOR_NAME_IDX = BLAME_SCHEMA.index_of("author_name")
+_AUTHOR_EMAIL_IDX = BLAME_SCHEMA.index_of("author_email")
+_AUTHORED_AT_IDX = BLAME_SCHEMA.index_of("authored_at")
+
+# A commit-info line: 40 hex digits, a space, the original line number,
+# the final line number, and (only on the first line of a same-commit
+# run) a trailing count - e.g. "feb78aa9...5e2cd8 1 1 4" or "...cd8 2 2".
+# Matched by pattern, not by position - the production parser instead
+# tracks *where* it is in the block; this oracle tracks *what a line
+# looks like*.
+_HEADER_RE = re.compile(r"^[0-9a-f]{40} \d+ \d+(?: \d+)?$")
+
+
+def _oracle_authored_at(unix_time: int) -> str:
+    return datetime.fromtimestamp(unix_time, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _oracle_parse_porcelain(text: str, path: str) -> list[Row]:
+    """An independently-written `git blame --line-porcelain` parser.
+
+    Accumulates header fields into a dict keyed by their porcelain
+    field name, keyed off a regex match for the commit-info line
+    rather than "the line right after the last content line". A
+    content line is still identified by a leading tab checked first -
+    that part is not a design choice either implementation is free to
+    vary, it is simply what the format is - but nothing else about how
+    this function locates record boundaries matches the production
+    parser's approach.
+    """
+    rows: list[Row] = []
+    fields: dict[str, str] = {}
+    commit_hash: str | None = None
+    line_no: int | None = None
+    for line in text.split("\n"):
+        if line.startswith("\t"):
+            content = line[1:]
+            assert commit_hash is not None and line_no is not None
+            rows.append(
+                (
+                    path,
+                    line_no,
+                    content,
+                    commit_hash,
+                    fields["author"],
+                    fields["author-mail"].strip("<>"),
+                    _oracle_authored_at(int(fields["author-time"])),
+                )
+            )
+            fields = {}
+            continue
+        if line == "":
+            continue
+        if _HEADER_RE.match(line):
+            parts = line.split(" ")
+            commit_hash = parts[0]
+            line_no = int(parts[2])
+            continue
+        if " " in line:
+            key, _, value = line.partition(" ")
+            fields[key] = value
+        # A bare keyword line with no value ("boundary") - ignored,
+        # same as the production parser ignores anything it does not
+        # need.
+    return rows
+
+
+def _oracle_list_paths(repo: Path) -> list[str]:
+    """Independently enumerate paths at HEAD via `ls-tree -z`. This is
+    the same flag choice `historian.tables.blame.list_paths` makes,
+    because it is the only correct one (the grooming finding that
+    unqualified `--name-only` quote-escapes the `awkward` fixture's
+    path) - not a parsing algorithm there is a second way to write."""
+    raw = subprocess.run(
+        ["git", "ls-tree", "-rz", "HEAD", "--name-only"],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    ).stdout
+    return [chunk.decode("utf-8", errors="replace") for chunk in raw.split(b"\0") if chunk]
+
+
+def _oracle_blame(repo: Path, path: str) -> list[Row]:
+    raw = subprocess.run(
+        ["git", "blame", "--line-porcelain", "HEAD", "--", path],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    ).stdout
+    return _oracle_parse_porcelain(raw.decode("utf-8", errors="replace"), path)
+
+
+def _oracle_scan(repo: Path) -> list[Row]:
+    rows: list[Row] = []
+    for path in _oracle_list_paths(repo):
+        rows.extend(_oracle_blame(repo, path))
+    return rows
+
+
+def _by_path(rows: list[Row]) -> dict[str, list[Row]]:
+    grouped: dict[str, list[Row]] = {}
+    for row in rows:
+        grouped.setdefault(row[_PATH_IDX], []).append(row)
+    return grouped
+
+
+# --- tiny --------------------------------------------------------------
+
+
+def test_tiny_matches_the_oracle(tiny_repo):
+    """The scan's full row set, order aside, equals the independent
+    oracle's - the strongest single check available, and it subsumes
+    "every column populated" and "line_no is git's own line number"
+    for every row `tiny` produces."""
+    actual = sorted(BlameScan(tiny_repo).scan())
+    expected = sorted(_oracle_scan(tiny_repo))
+    assert actual == expected
+
+
+def test_tiny_yields_exactly_three_rows_over_two_surviving_paths(tiny_repo):
+    """`docs/todo.md` (deleted before HEAD) and `src/util.py` (the
+    pre-rename path) contribute nothing - matches
+    `git ls-tree -r HEAD --name-only` at HEAD."""
+    rows = list(BlameScan(tiny_repo).scan())
+    grouped = _by_path(rows)
+    assert set(grouped) == {"src/utils.py", "feature/thing.py"}
+    assert len(grouped["src/utils.py"]) == 2
+    assert len(grouped["feature/thing.py"]) == 1
+    assert len(rows) == 3
+
+
+def test_tiny_rename_is_followed_back_to_the_root_commit(tiny_repo):
+    """`src/utils.py` was renamed from `src/util.py` with no content
+    change (`tests/fixtures/build.py`'s `_verify_tiny` already pins
+    this at the fixture-build level). Every line's `commit_hash` must
+    therefore be the pre-rename root commit, not the rename commit."""
+    root = subprocess.run(
+        ["git", "rev-list", "--max-parents=0", "HEAD"],
+        cwd=tiny_repo,
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout.strip()
+
+    rows = [row for row in BlameScan(tiny_repo).scan() if row[_PATH_IDX] == "src/utils.py"]
+    assert len(rows) == 2
+    assert all(row[_COMMIT_HASH_IDX] == root for row in rows)
+
+
+def test_tiny_never_blames_a_path_absent_from_ls_tree(tiny_repo, monkeypatch):
+    """`docs/todo.md` is tracked in history but not at HEAD - the scan
+    must never invoke `git blame` on it. Checked by recording every
+    git invocation's argv, per spec §4's pushdown-layer approach:
+    "Scans record what they did ... tests read it" (here, the test
+    itself is the recorder, via a spy on `subprocess.run`)."""
+    calls: list[list[str]] = []
+    real_run = subprocess.run
+
+    def spy(args, *a, **kw):
+        calls.append(list(args))
+        return real_run(args, *a, **kw)
+
+    monkeypatch.setattr(blame.subprocess, "run", spy)
+
+    list(BlameScan(tiny_repo).scan())
+
+    blamed_paths = [call[-1] for call in calls if len(call) >= 2 and call[1] == "blame"]
+    assert set(blamed_paths) == {"src/utils.py", "feature/thing.py"}
+    assert "docs/todo.md" not in blamed_paths
+
+
+# --- awkward -------------------------------------------------------------
+
+
+def test_awkward_matches_the_oracle(awkward_repo):
+    actual = sorted(BlameScan(awkward_repo).scan())
+    expected = sorted(_oracle_scan(awkward_repo))
+    assert actual == expected
+
+
+def test_awkward_yields_exactly_twelve_rows(awkward_repo):
+    rows = list(BlameScan(awkward_repo).scan())
+    grouped = _by_path(rows)
+    expected_counts = {
+        "café.py": 6,
+        'a "quoted" name.txt': 1,
+        "binary.bin": 1,
+        "empty.txt": 0,
+        "no_newline.txt": 3,
+        "phoenix.txt": 1,
+    }
+    assert set(grouped) == {path for path, count in expected_counts.items() if count > 0}
+    for path, count in expected_counts.items():
+        assert len(grouped.get(path, [])) == count, path
+    assert len(rows) == 12
+
+
+def test_awkward_every_row_has_all_seven_columns_populated(awkward_repo):
+    """Blame never leaves a surviving line unattributed."""
+    for row in BlameScan(awkward_repo).scan():
+        assert len(row) == len(BLAME_SCHEMA.columns)
+        assert all(value is not None for value in row), row
+
+
+def test_line_no_is_always_a_python_int_never_a_bool_never_a_str(awkward_repo):
+    for row in BlameScan(awkward_repo).scan():
+        line_no = row[_LINE_NO_IDX]
+        assert isinstance(line_no, int)
+        assert not isinstance(line_no, bool)
+
+
+def test_authored_at_is_iso8601_utc(awkward_repo):
+    pattern = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+    for row in BlameScan(awkward_repo).scan():
+        assert pattern.match(row[_AUTHORED_AT_IDX]), row[_AUTHORED_AT_IDX]
+
+
+def test_empty_file_contributes_zero_rows_not_an_error(awkward_repo):
+    """Confirmed independently that `git blame --line-porcelain
+    empty.txt` exits 0 with empty stdout - so this must not raise and
+    must not produce one row with empty content."""
+    rows = [row for row in BlameScan(awkward_repo).scan() if row[_PATH_IDX] == "empty.txt"]
+    assert rows == []
+
+
+def test_lookalike_line_is_content_not_a_header(awkward_repo):
+    """café.py's line 4 is real file content that reads exactly like a
+    porcelain `author` header once its leading tab is stripped. It
+    must appear verbatim as that row's `line`, attributed identically
+    to lines 1-3 - proving the parser told a real header from content
+    by the leading tab, not by matching header keywords against text."""
+    cafe_rows = {
+        row[_LINE_NO_IDX]: row
+        for row in BlameScan(awkward_repo).scan()
+        if row[_PATH_IDX] == "café.py"
+    }
+    assert cafe_rows[4][_LINE_IDX] == AWKWARD_LOOKALIKE_LINE
+    first_commit_attribution = (
+        cafe_rows[1][_COMMIT_HASH_IDX],
+        cafe_rows[1][_AUTHOR_NAME_IDX],
+        cafe_rows[1][_AUTHOR_EMAIL_IDX],
+    )
+    for line_no in (2, 3, 4):
+        assert (
+            cafe_rows[line_no][_COMMIT_HASH_IDX],
+            cafe_rows[line_no][_AUTHOR_NAME_IDX],
+            cafe_rows[line_no][_AUTHOR_EMAIL_IDX],
+        ) == first_commit_attribution
+
+
+def test_quoted_path_is_exact_not_reescaped(awkward_repo):
+    """`path` must be the literal path (space and double quote intact,
+    no backslash escaping), sourced from `ls-tree -z` enumeration - not
+    parsed from the porcelain `filename` header, which re-quotes it as
+    `"a \\"quoted\\" name.txt"`."""
+    rows = [
+        row for row in BlameScan(awkward_repo).scan() if row[_PATH_IDX] == 'a "quoted" name.txt'
+    ]
+    assert len(rows) == 1
+    assert rows[0][_PATH_IDX] == 'a "quoted" name.txt'
+
+
+def test_binary_line_is_a_stable_str(awkward_repo):
+    """`binary.bin`'s single row's `line` is a `str` (never `bytes`,
+    never raises), decoded as UTF-8 with `errors="replace"`, and the
+    same value on every run."""
+    first = [row for row in BlameScan(awkward_repo).scan() if row[_PATH_IDX] == "binary.bin"]
+    second = [row for row in BlameScan(awkward_repo).scan() if row[_PATH_IDX] == "binary.bin"]
+    assert len(first) == 1
+    assert isinstance(first[0][_LINE_IDX], str)
+    assert first == second
+
+
+def test_no_newline_file_three_rows_no_injected_newline(awkward_repo):
+    rows = sorted(
+        (row for row in BlameScan(awkward_repo).scan() if row[_PATH_IDX] == "no_newline.txt"),
+        key=lambda row: row[_LINE_NO_IDX],
+    )
+    assert len(rows) == 3
+    assert rows[0][_LINE_IDX] == "first line"
+    assert rows[1][_LINE_IDX] == "second line"
+    assert rows[2][_LINE_IDX] == "third line without a trailing newline"
+
+
+def test_phoenix_attributed_to_the_recreation_commit_not_the_original(awkward_repo):
+    """`phoenix.txt` was added, deleted, then recreated with different
+    content and an empty commit message (the third commit, which is
+    also `AWKWARD_HEAD`). Its single row must be attributed to that
+    recreation, proving the scan reads content at HEAD rather than
+    walking full file history back to the original add."""
+    rows = [row for row in BlameScan(awkward_repo).scan() if row[_PATH_IDX] == "phoenix.txt"]
+    assert len(rows) == 1
+    assert rows[0][_COMMIT_HASH_IDX] == AWKWARD_HEAD
+
+
+# --- The pushdown-interface stub (M4's real work is #13/#14) -------------
+
+
+def test_capabilities_is_empty(tiny_repo):
+    assert BlameScan(tiny_repo).capabilities() == set()
+
+
+def test_scan_ignores_pushed_entirely(tiny_repo):
+    """No pushdown is attempted: calling `scan()` with a non-empty or
+    nonsensical `pushed` argument produces the identical full row set
+    as calling it with none - a predicate that cannot push down must
+    still produce correct results (spec §4)."""
+    baseline = sorted(BlameScan(tiny_repo).scan())
+    with_garbage = sorted(BlameScan(tiny_repo).scan(pushed=[object(), "not a predicate", 42]))
+    assert with_garbage == baseline
+
+
+# --- Unit-level: no repository needed -------------------------------------
+
+
+def test_zero_paths_yields_zero_rows_no_repository_needed():
+    """The loop over `paths` in `blame_paths` never runs when `paths`
+    is empty, so no git command is ever invoked - a nonexistent repo
+    path is fine."""
+    rows = list(blame.blame_paths(Path("/nonexistent/not-a-repo"), []))
+    assert rows == []
+
+
+# --- Determinism -----------------------------------------------------------
+
+
+def test_scanning_twice_is_byte_identical_and_same_order(awkward_repo):
+    """Per AGENTS.md: the same repository and the same query always
+    produce the same rows in the same order."""
+    first = list(BlameScan(awkward_repo).scan())
+    second = list(BlameScan(awkward_repo).scan())
+    assert first == second

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -281,9 +281,18 @@ def test_text_compares_bytewise():
 
 
 def test_text_comparison_is_bytewise_for_non_ascii():
-    """UTF-8 byte order coincides with code point order for all of
-    Unicode, so Python's default string ordering already matches
-    SQLite's BINARY collation. Pinned down rather than assumed."""
+    """UTF-8 byte order coincides with code point order for every
+    string historian actually produces - not "for all of Unicode" in
+    general, which is false for a lone surrogate (issue #20: a string
+    containing one sorts inconsistently with its own UTF-8 bytes).
+    What makes the narrower claim true is historian's own decoding
+    policy, not a fact about Unicode: git bytes are decoded as UTF-8
+    with `errors="replace"` (`tables/blame.py`, settled by #20's
+    grooming), which can never produce a lone surrogate, so no string
+    this module ever compares can exhibit the mismatch. Python's
+    default string ordering therefore matches SQLite's BINARY
+    collation for every value in play here. Pinned down rather than
+    assumed."""
     assert lt("é", "z") is False
     assert lt("z", "é") is True
     assert gt("é", "z") is True


### PR DESCRIPTION
Closes #11. Closes #20.

The first code in this project allowed to touch git, and per §1 the reason historian exists: `blame` is the table that cannot be materialised in advance.

## What this adds

**`src/historian/schema.py`** — `Schema`, `Column`, `ColumnType`, `Row`. Dependency-free, sibling to `values.py`, importing nothing from `sql/`, `plan/` or `exec/`.

#9's body had said the binder would own these. Grooming moved them here because #11 now goes first and §3 puts the schema on the operator — and a scan is an operator, so it cannot wait. #9 keeps the table catalog and imports blame's schema; coordinating comments are on both #9 and #12 so neither invents half of it.

**`src/historian/tables/blame.py`** — enumeration, the `--line-porcelain` parser, and `BlameScan` with §2's seven columns. `subprocess` appears here and nowhere else under `src/`, per `AGENTS.md`.

The scan's *call convention* exists — `capabilities()` returns an empty set, `scan(pushed)` accepts and provably ignores its argument — but `PushdownKind` and `Predicate` are deliberately **not** invented as types. Neither exists yet, and defining them now would likely contradict M4's actual negotiation design in #13. §1 wants the interface shaped early; it does not want types guessed a milestone ahead of their design.

**`tests/extraction/test_blame.py`** — §4's extraction layer, checked against real `git blame --line-porcelain`.

## Two corrections to the spec, found by running commands rather than reading them

§2 described enumeration as `git ls-tree -r HEAD --name-only`. Against the `awkward` fixture:

```
git ls-tree -r  HEAD --name-only   ->  "a \"quoted\" name.txt"    quote-escaped
git ls-tree -rz HEAD --name-only   ->  a "quoted" name.txt        raw
```

And `git blame --line-porcelain`'s own `filename` header re-quotes identically, with **no unquoted form available**:

```
filename "a \"quoted\" name.txt"
```

So `path` can only ever come from the scan's own `-z` enumeration, never from that header. A parser trusting the header produces a wrong path for exactly the file the fixture was built to catch. §2 now says both things, since the spec is meant to describe historian as it currently is and it was describing something subtly broken.

This is #10 and #11 working as designed: the awkward fixture existed to break this parser, and it did its job before the parser shipped rather than after.

## The decoding policy (#20)

Git paths and file contents are arbitrary bytes. §2 says `path` and `line` are TEXT and was silent on how bytes become text.

**UTF-8 with `errors="replace"`, not `surrogateescape`**, and the reason is not a matter of taste:

```
surrogateescape  ->  UnicodeEncodeError: surrogates not allowed
replace          ->  inserts, round-trips equal
```

`surrogateescape` produces a Python `str` that the `sqlite3` module **cannot insert at all**. §1 makes SQLite the definition of correct, and M3's differential harness loads every scanned row into SQLite — so that choice would have made the oracle itself unusable, surfacing in M3 as a harness crash rather than as a decoding bug, long after the context was gone.

It also settles a loose end from the M1 review. `tests/test_values.py` asserted that UTF-8 byte order coincides with code-point order "for all of Unicode", which is false for a lone surrogate. Rather than deleting the claim, the docstring now states the true narrower one: `errors="replace"` can never produce a lone surrogate, so no string this code can produce exhibits the mismatch. The finding closes by making the comment true.

Recorded in `_docs/decisions.md`, including the honest coverage gap — neither fixture exercises non-UTF-8 bytes in a *path* as opposed to file content. Same decode call either way, so a coverage remark rather than an open question.

## Verification

**QA verdict: PASS** — https://github.com/ionut-banu/historian/issues/11#issuecomment-5493846739

All **21 acceptance criteria** ticked with per-criterion evidence. `uv run pytest` gives **464 passed**, against 445 on `main`.

`Differential: n/a, no suite until M3` · `Fuzzer: n/a, not built until M5`

What was checked beyond the criteria:

- **QA broke the parser and watched it fail.** It sabotaged `_parse_porcelain` into the exact naive strip-then-match bug the awkward fixture's lookalike line targets, confirmed precisely the three expected tests turned red with line 4 misparsed as `# appended by Sam`, then restored the file. The engineer reported doing the same independently. A test that has never failed has not been shown to test anything.
- **The oracle is genuinely independent.** The extraction test writes its own `_oracle_parse_porcelain`, `_oracle_list_paths` and `_oracle_blame` rather than calling the scan's parser — so a shared bug cannot pass on both sides, which is the failure mode §4's extraction layer exists to prevent.
- **`authored_at` derives from `author-time`, not `author-tz`** — verified by pulling the raw porcelain fields independently. §2 requires ISO-8601 UTC because it makes `authored_at > '2026-01-01'` behave identically in both engines with no conversion layer.
- **Every emitted row round-trips through an in-memory `sqlite3` table byte-identical**, with no lone surrogate anywhere. That is exactly what M3 will do to these rows.
- Determinism: the scan run twice over both fixtures produces byte-identical output, as `AGENTS.md` requires.
- Layering: `subprocess` appears nowhere under `src/historian/` except `tables/blame.py`.
- Edge cases: a repository with a commit but no tracked files yields zero rows and no error; an empty file contributes zero rows; an unborn `HEAD` raises rather than failing silently.

The emitted paths, end to end:

```
'a "quoted" name.txt'     <- raw, not escaped
'binary.bin'
'café.py'
'no_newline.txt'
'phoenix.txt'

column types: [str, int, str, str, str, str, str]    line_no the only INTEGER
```

## Not in scope

Pushdown is M4 (#13/#14) — this scan produces every row and the `Filter` above it will do the work. Grooming recommended against splitting this issue: unlike #8, where the split-off part was six unrelated rules, everything here serves one feature and none of it ships independently.
