### PR TITLE
The binder: name resolution and unknown name errors (#9)

### DIFF
--- a/src/historian/sql/binder.py
+++ b/src/historian/sql/binder.py
@@ -1,0 +1,449 @@
+"""Name resolution: AST -> bound AST, or a structured error.
+
+The fourth stage of the pipeline in `_docs/spec.md` §3
+("binder     AST + resolved columns, errors for unknown names").
+Consumes the `SelectStatement` `sql/parser.py` builds and the table
+catalog this module owns, resolves every table and column reference
+against them, and produces a new tree in which every column reference
+is a zero-based integer offset into a `Row` - never a name
+`exec/expression.py` (#12) would need to look up per row, per §3's
+"column references resolve to integer offsets at bind time rather
+than by name at runtime."
+
+Issue #9. Implements the binder half of §3's pipeline plus the
+table-catalog half of §2 that `schema.py` and `tables/blame.py` both
+leave to this module (see both modules' docstrings).
+
+Not in this module
+-------------------
+
+**Type/affinity checking** - `WHERE line_no = '5'` binds successfully
+here; whether `'5'` needs coercing to compare against an `INTEGER`
+column is `exec/expression.py`'s job (#12), per spec §3's explicit
+split. **Function name/arity validation** - no registry of built-ins
+exists yet; `SELECT nonexistent_fn(path) FROM blame` binds
+successfully. **`WHERE` resolving a select-list alias** - real,
+verified SQLite behaviour (`select path as p, line_no from blame
+where p = 'a.py'` succeeds via the alias) that needs expression
+substitution, not plain offset resolution, because `WHERE` runs before
+`Project` computes any alias. Deferred to #32; until it lands, `WHERE
+<alias>` conservatively raises "no such column" - a query SQLite
+accepts gets wrongly rejected, which is the safe direction. **The
+rendered `error: ...` / caret / "blame has: ..." box from spec §5** -
+milestone item 18; `BindError` here carries structured fields
+(message, position, available names), not text to print.
+
+Bound tree shape
+-----------------
+
+`sql/ast.py`'s node types are frozen, so this module cannot annotate
+them in place - it builds a new tree instead. Every `Expr` node type
+that carries no name to resolve (`Literal`, `BinaryOp`, `And`, `Or`,
+`Not`, `Is`, `Like`, `In`, `Between`, `UnaryOp`, `FunctionCall`) is
+reused unchanged as a *type*: this module walks into its children and
+rebuilds the node via `dataclasses.replace` with the bound children in
+place of the originals. `ColumnRef` is the one node type that does
+carry a name, and every occurrence of it is replaced by `BoundColumnRef`,
+a new leaf carrying the resolved integer offset plus enough to render
+an error later (the resolved name, the position). `Star` is expanded
+away entirely at the select-list level, into one `BoundColumnRef` per
+column of the FROM table's schema in declared order - except as the
+sole, unqualified argument of a `FunctionCall` (`count(*)`), where it
+is passed through untouched: `*` there means "no columns", not "all
+columns", and this module does not validate that the function name is
+real.
+
+Because v1 has exactly one FROM table and no `JOIN`, a `BoundColumnRef`
+does not track which table it came from - the offset alone is
+unambiguous. Building multi-table bookkeeping now, before there is a
+`JOIN` to need it, is exactly the kind of speculative generality
+`AGENTS.md` asks to redesign rather than pre-build.
+
+ASCII-only case folding
+-------------------------
+
+SQLite folds only `A`-`Z`/`a`-`z` when matching an identifier, not
+Python's Unicode-aware `str.lower()`/`str.casefold()`. Confirmed
+against `sqlite3` 3.51.0: `select STRASSE from t` (table `t(straße
+text)`) fails with "no such column: STRASSE", while `select STRAßE
+from t` succeeds - `ß` is left alone rather than folded to `SS`, which
+is exactly what `'straße'.upper() == 'STRASSE'` would wrongly do in
+Python. `_ascii_fold` below implements SQLite's rule directly: only
+the 26 ASCII letters move, nothing else is consulted.
+
+Resolution and error order
+----------------------------
+
+Confirmed against `sqlite3` by constructing queries with more than one
+thing wrong at once: the `FROM` table is resolved first, before
+anything else (`select authr_name from ghost` reports the missing
+table). Within a clause, the leftmost unresolved name wins (`select
+ghost1, ghost2 from blame` reports `ghost1`). The select list resolves
+before `WHERE` (`select ghost_select from blame where ghost_where = 1`
+reports `ghost_select`). This is *not* `SelectStatement`'s own field
+order (`select_list`, `from_table`, `where`) - `bind()` below checks
+`from_table` first regardless, which a naive walk of the dataclass's
+fields would get backward.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+
+from historian.schema import Schema
+from historian.sql.ast import (
+    And,
+    Between,
+    BinaryOp,
+    ColumnRef,
+    Expr,
+    FunctionCall,
+    In,
+    Is,
+    Like,
+    Literal,
+    Not,
+    Or,
+    SelectItem,
+    SelectStatement,
+    Star,
+    UnaryOp,
+)
+from historian.sql.lexer import Position
+from historian.tables.blame import BLAME_SCHEMA
+
+__all__ = [
+    "BindError",
+    "BoundColumnRef",
+    "BoundSelectItem",
+    "BoundSelectStatement",
+    "TABLES",
+    "bind",
+]
+
+#: The table catalog: FROM-clause name -> `Schema`. Phase 1 has exactly
+#: one table. `BLAME_SCHEMA` is imported from `historian.tables.blame`
+#: rather than redefined here, per that module's own docstring and the
+#: #9/#11 grooming coordination comment. Note: importing it transitively
+#: imports `tables/blame.py`, which imports `subprocess` at module
+#: level - the module is merely imported, never invoked, so no git
+#: repository or subprocess call is needed to exercise this module, but
+#: this file's own import graph is not literally subprocess-free. That
+#: trade-off was made by the grooming decision this catalog implements,
+#: not revisited here.
+TABLES: dict[str, Schema] = {"blame": BLAME_SCHEMA}
+
+
+# --- Errors ------------------------------------------------------------
+#
+# Same shape as `LexError` (`sql/lexer.py`) and `ParseError`
+# (`sql/parser.py`): message via `Exception.__init__`, plus a
+# `.position` attribute, so a caller can report it per spec §5 without
+# a traceback ever reaching the user. `.available` is this module's own
+# addition - the names that *would* have resolved, for the eventual
+# "blame has: ..." rendering (#18), never used by this module itself.
+
+
+class BindError(Exception):
+    """A table or column reference in the statement does not resolve
+    against the catalog, or a `Star` appears somewhere it cannot mean
+    anything (see the module docstring).
+
+    Structured, not rendered: `message` is plain text naming the
+    problem, `position` points at the offending token, and `available`
+    lists what the caller could have referred to instead - table names
+    for an unresolved table, column names in schema order for an
+    unresolved column. Rendering this per spec §5 (the caret, "blame
+    has: ...") is milestone item 18, not this module.
+    """
+
+    def __init__(self, message: str, position: Position, available: tuple[str, ...]) -> None:
+        super().__init__(message)
+        self.position = position
+        self.available = available
+
+
+# --- Bound tree ----------------------------------------------------------
+#
+# Frozen dataclasses, matching `sql/ast.py`'s own convention. Only one
+# new node type: every other `Expr` in a bound tree is one of
+# `sql/ast.py`'s own types, reused unchanged as a type and rebuilt
+# (via `dataclasses.replace`) only where a descendant changed.
+
+
+@dataclass(frozen=True)
+class BoundColumnRef(Expr):
+    """A resolved column reference: everywhere a `ColumnRef` used to be.
+
+    `offset` is the column's zero-based position in the FROM table's
+    schema, computed once via `Schema.index_of` - the mechanism spec
+    §3 describes for keeping row access by offset rather than by name.
+    `name` is the column's declared schema spelling (used for an
+    unaliased select-list item's output name; see `BoundSelectItem`).
+    `position` is inherited from the original `ColumnRef` (or, for a
+    `Star`-expansion item, from the `Star` itself), so an error found
+    later can still point at source text.
+    """
+
+    offset: int
+    name: str
+    position: Position
+
+
+@dataclass(frozen=True)
+class BoundSelectItem:
+    """One resolved entry in a `SELECT` list.
+
+    `output_name` is the header this item produces: the explicit
+    `alias`, used verbatim with no folding, when one was written;
+    otherwise the declared schema spelling when `expr` is a
+    `BoundColumnRef`; otherwise `None` - an unaliased, non-column
+    expression's header is not something this issue's criteria pin
+    down, and nothing downstream yet consumes it.
+    """
+
+    expr: Expr
+    alias: str | None
+    output_name: str | None
+    position: Position
+
+
+@dataclass(frozen=True)
+class BoundSelectStatement:
+    """A `SelectStatement` with every table and column reference
+    resolved. `from_table` is the catalog's own key for the FROM
+    table (its declared spelling), not necessarily the casing the
+    query used."""
+
+    select_list: tuple[BoundSelectItem, ...]
+    from_table: str
+    where: Expr | None
+    position: Position
+
+
+# --- ASCII-only folding --------------------------------------------------
+
+
+def _ascii_fold(text: str) -> str:
+    """Fold only the ASCII letters `A`-`Z` to `a`-`z`; leave every other
+    character - including every character outside ASCII - untouched.
+
+    This is SQLite's own identifier-matching rule, not Python's
+    Unicode-aware `str.lower()`. See the module docstring for the
+    `straße`/`STRASSE`/`STRAßE` evidence this must agree with.
+    """
+    return "".join(chr(ord(ch) + 32) if "A" <= ch <= "Z" else ch for ch in text)
+
+
+def _same_name(a: str, b: str) -> bool:
+    """ASCII case-insensitive identifier equality."""
+    return _ascii_fold(a) == _ascii_fold(b)
+
+
+# --- Binding context -------------------------------------------------------
+#
+# A plain, immutable bundle of what every resolution needs: the FROM
+# table's own schema and declared name (v1 has exactly one), and the
+# catalog's full set of table names for a "no such table" error's
+# `available` data. Not global state and not a class with behaviour -
+# just the three things every helper below would otherwise need as
+# separate parameters.
+
+
+@dataclass(frozen=True)
+class _Context:
+    schema: Schema
+    table_name: str
+    catalog_names: tuple[str, ...]
+
+
+# --- FROM-table resolution -------------------------------------------------
+
+
+def _resolve_table(stmt: SelectStatement, catalog: dict[str, Schema]) -> _Context:
+    """Resolve `stmt.from_table` against `catalog`, case-insensitively
+    and ASCII-only. Checked first, before any select-list or WHERE
+    name, per the module docstring's resolution-order evidence.
+
+    The error's position is `stmt.position` (the `SELECT` keyword):
+    `from_table` is a bare string on the AST with no position of its
+    own to point a caret at. Confirmed this is not a gap to route
+    around: `sqlite3`'s own CLI likewise prints no caret for "no such
+    table" (only for "no such column"), so a future renderer (#18) is
+    not expected to place one here either.
+    """
+    for catalog_name, schema in catalog.items():
+        if _same_name(catalog_name, stmt.from_table):
+            return _Context(schema=schema, table_name=catalog_name, catalog_names=tuple(catalog.keys()))
+    raise BindError(f"no such table: {stmt.from_table}", stmt.position, tuple(catalog.keys()))
+
+
+# --- Column and Star resolution --------------------------------------------
+
+
+def _bind_column_ref(ref: ColumnRef, ctx: _Context) -> BoundColumnRef:
+    """Resolve a bare or table-qualified `ColumnRef`.
+
+    A qualifier that does not match the FROM table - whether a real,
+    unrelated table or an unknown name - raises "no such column:
+    <qualifier>.<name>", the whole dotted reference verbatim, never
+    "no such table". This is the opposite of `_bind_star`'s qualifier
+    check below; both are separately confirmed against `sqlite3` and
+    must not be unified.
+    """
+    if ref.table is not None and not _same_name(ref.table, ctx.table_name):
+        raise BindError(f"no such column: {ref.table}.{ref.name}", ref.position, ctx.schema.names)
+    for offset, column in enumerate(ctx.schema.columns):
+        if _same_name(column.name, ref.name):
+            return BoundColumnRef(offset=offset, name=column.name, position=ref.position)
+    display = f"{ref.table}.{ref.name}" if ref.table is not None else ref.name
+    raise BindError(f"no such column: {display}", ref.position, ctx.schema.names)
+
+
+def _bind_star(star: Star, ctx: _Context) -> list[BoundColumnRef]:
+    """Expand `*` / `table.*` into one `BoundColumnRef` per column of
+    the FROM table's schema, in declared order.
+
+    A qualifier that does not match the FROM table raises "no such
+    table: <qualifier>", never "no such column" - confirmed against
+    `sqlite3` for both an unrelated real table and an unknown name,
+    and the opposite of `_bind_column_ref`'s qualifier check above.
+    """
+    if star.table is not None and not _same_name(star.table, ctx.table_name):
+        raise BindError(f"no such table: {star.table}", star.position, ctx.catalog_names)
+    return [
+        BoundColumnRef(offset=offset, name=column.name, position=star.position)
+        for offset, column in enumerate(ctx.schema.columns)
+    ]
+
+
+# --- General expression binding --------------------------------------------
+#
+# One case per `sql/ast.py` node type. Every type other than
+# `ColumnRef` and `Star` is reused unchanged and rebuilt via
+# `dataclasses.replace` with its children bound - no new type, no
+# dynamic dispatch, just an explicit `isinstance` chain matching the
+# style already established by the parser's own precedence methods.
+
+
+def _bind_expr(expr: Expr, ctx: _Context) -> Expr:
+    if isinstance(expr, Literal):
+        return expr
+    if isinstance(expr, ColumnRef):
+        return _bind_column_ref(expr, ctx)
+    if isinstance(expr, Star):
+        # A whole, alias-less select-list item and count(*)'s sole
+        # unqualified argument are handled by their own callers before
+        # ever reaching here - see `_bind_select_item` and the
+        # `FunctionCall` case below. Any other position is exactly the
+        # parser-permissiveness backstop the grooming asked for: `* AS
+        # alias`, `*` inside a general expression, and `count(blame.*)`
+        # (a *qualified* star as a function argument) all reach this
+        # branch and are rejected here rather than crashing or
+        # silently mis-expanding.
+        raise BindError(
+            "* is only allowed as a whole select-list item or the sole argument to a function call",
+            expr.position,
+            (),
+        )
+    if isinstance(expr, FunctionCall):
+        if len(expr.args) == 1 and isinstance(expr.args[0], Star) and expr.args[0].table is None:
+            # count(*): passed through unexpanded and unvalidated. `*`
+            # here means "no columns", not "all columns" - see the
+            # module docstring. A *qualified* sole argument
+            # (count(blame.*)) does not take this path and falls
+            # through to the general Star rejection above.
+            return expr
+        return dataclasses.replace(expr, args=tuple(_bind_expr(arg, ctx) for arg in expr.args))
+    if isinstance(expr, UnaryOp):
+        return dataclasses.replace(expr, operand=_bind_expr(expr.operand, ctx))
+    if isinstance(expr, Not):
+        return dataclasses.replace(expr, operand=_bind_expr(expr.operand, ctx))
+    if isinstance(expr, BinaryOp):
+        return dataclasses.replace(expr, left=_bind_expr(expr.left, ctx), right=_bind_expr(expr.right, ctx))
+    if isinstance(expr, And):
+        return dataclasses.replace(expr, left=_bind_expr(expr.left, ctx), right=_bind_expr(expr.right, ctx))
+    if isinstance(expr, Or):
+        return dataclasses.replace(expr, left=_bind_expr(expr.left, ctx), right=_bind_expr(expr.right, ctx))
+    if isinstance(expr, Is):
+        return dataclasses.replace(expr, left=_bind_expr(expr.left, ctx), right=_bind_expr(expr.right, ctx))
+    if isinstance(expr, Like):
+        return dataclasses.replace(expr, left=_bind_expr(expr.left, ctx), pattern=_bind_expr(expr.pattern, ctx))
+    if isinstance(expr, In):
+        return dataclasses.replace(
+            expr, left=_bind_expr(expr.left, ctx), values=tuple(_bind_expr(v, ctx) for v in expr.values)
+        )
+    if isinstance(expr, Between):
+        return dataclasses.replace(
+            expr,
+            operand=_bind_expr(expr.operand, ctx),
+            low=_bind_expr(expr.low, ctx),
+            high=_bind_expr(expr.high, ctx),
+        )
+    raise AssertionError(f"sql/binder.py: unhandled expression node type {type(expr).__name__}")
+
+
+# --- Select-list binding ----------------------------------------------------
+
+
+def _bind_select_item(item: SelectItem, ctx: _Context) -> list[BoundSelectItem]:
+    """Bind one select-list item, expanding a `Star` into several
+    `BoundSelectItem`s or resolving an ordinary expression into one.
+
+    Aliases do not enter a namespace visible to other select-list
+    items: each item is resolved against `ctx.schema` alone, with no
+    reference to any other item's alias. Confirmed against `sqlite3`
+    (`select path as p, p as p2 from blame` fails on the second item)
+    - and nothing extra needs implementing here for that, since this
+    function never looks past its own `item`.
+    """
+    if isinstance(item.expr, Star):
+        if item.alias is not None:
+            # `* AS alias` - parses today (#31, a parser bug) but is a
+            # syntax error in `sqlite3`. Same defensive backstop as
+            # the general Star case in `_bind_expr`.
+            raise BindError(
+                "* is only allowed as a whole select-list item or the sole argument to a function call",
+                item.position,
+                (),
+            )
+        return [
+            BoundSelectItem(expr=bound, alias=None, output_name=bound.name, position=item.position)
+            for bound in _bind_star(item.expr, ctx)
+        ]
+    bound_expr = _bind_expr(item.expr, ctx)
+    if item.alias is not None:
+        output_name = item.alias
+    elif isinstance(bound_expr, BoundColumnRef):
+        output_name = bound_expr.name
+    else:
+        output_name = None
+    return [BoundSelectItem(expr=bound_expr, alias=item.alias, output_name=output_name, position=item.position)]
+
+
+# --- Entry point -------------------------------------------------------------
+
+
+def bind(stmt: SelectStatement, catalog: dict[str, Schema] = TABLES) -> BoundSelectStatement:
+    """Resolve every table and column reference in `stmt` against
+    `catalog`, and expand `SELECT *` / `table.*`.
+
+    Raises `BindError` - never returns `None`/`False` - on the first
+    name that does not resolve, in the order documented in the module
+    docstring: the FROM table, then the select list left to right,
+    then WHERE. `catalog` defaults to `TABLES`, the module's own
+    table catalog, but is a parameter (not hardcoded) so tests can
+    bind against a synthetic schema with no dependency on `blame`.
+    """
+    ctx = _resolve_table(stmt, catalog)
+    bound_items: list[BoundSelectItem] = []
+    for item in stmt.select_list:
+        bound_items.extend(_bind_select_item(item, ctx))
+    bound_where = _bind_expr(stmt.where, ctx) if stmt.where is not None else None
+    return BoundSelectStatement(
+        select_list=tuple(bound_items),
+        from_table=ctx.table_name,
+        where=bound_where,
+        position=stmt.position,
+    )

--- a/tests/test_binder.py
+++ b/tests/test_binder.py
@@ -1,0 +1,524 @@
+"""Tests for historian.sql.binder.
+
+Issue #9. Unit-style per spec §4's test-architecture table: asserts
+`bind()`'s output and errors directly against constructed
+`SelectStatement`/`Schema` values, no repository, no git, no SQLite
+process at test time. Every expected value below was independently
+checked against the `sqlite3` command-line tool (3.51.0) during this
+issue's own work, not merely carried over from the issue's grooming -
+the query used is quoted above each group, matching `tests/
+test_parser.py`'s convention.
+
+`_bind` binds real parsed SQL against the real `blame` schema, via
+`historian.sql.binder.TABLES` (`{"blame": BLAME_SCHEMA}`) - the same
+catalog `bind()` defaults to. A few tests instead bind a hand-built
+`SelectStatement` against a synthetic single-column schema (for the
+ASCII-folding case, where blame has no non-ASCII column) or a
+hand-built AST bypassing the parser entirely (for the defensive
+`Star`-in-a-bad-position backstop, since real SQL cannot construct
+that shape once #31 is fixed - see the issue's own grooming notes).
+"""
+
+import dataclasses
+
+import pytest
+
+from historian.schema import Column, ColumnType, Schema
+from historian.sql.ast import (
+    ColumnRef,
+    FunctionCall,
+    Literal,
+    SelectItem,
+    SelectStatement,
+    Star,
+)
+from historian.sql.binder import (
+    TABLES,
+    BindError,
+    BoundColumnRef,
+    BoundSelectStatement,
+    bind,
+)
+from historian.sql.lexer import Position, tokenize
+from historian.sql.parser import parse
+from historian.tables.blame import BLAME_SCHEMA
+
+_POS = Position(line=1, column=1, offset=0)
+
+#: `blame`'s declared column order, per spec §2 - used throughout to
+#: assert `*` expansion and "no such column" `available` data.
+_BLAME_COLUMNS = ("path", "line_no", "line", "commit_hash", "author_name", "author_email", "authored_at")
+
+
+def _bind(sql: str) -> BoundSelectStatement:
+    return bind(parse(tokenize(sql)))
+
+
+# --- The catalog -------------------------------------------------------------
+
+
+def test_tables_catalog_is_exactly_blame():
+    """`sql/binder.py` exposes `TABLES: dict[str, Schema]` seeded with
+    exactly `{"blame": BLAME_SCHEMA}`, importing rather than
+    redefining the schema - per the issue's own coordination note with
+    #11's grooming."""
+    assert TABLES == {"blame": BLAME_SCHEMA}
+    assert TABLES["blame"] is BLAME_SCHEMA
+
+
+# --- FROM-table resolution, case-insensitive and ASCII-only ------------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT path FROM blame",
+        "SELECT path FROM BLAME",
+        "SELECT path FROM BlAmE",
+        'SELECT path FROM "BLAME"',
+    ],
+)
+def test_from_table_resolves_case_insensitively(sql):
+    """`select path from BLAME` and quoted `"BLAME"` both succeed
+    against `create table blame(...)` - confirmed with sqlite3."""
+    bound = _bind(sql)
+    assert bound.from_table == "blame"
+
+
+def test_unknown_from_table_raises_no_such_table():
+    """`sqlite3`: `select path from ghost;` -> "no such table: ghost"."""
+    with pytest.raises(BindError) as exc_info:
+        _bind("SELECT path FROM ghost")
+    err = exc_info.value
+    assert str(err) == "no such table: ghost"
+    assert err.available == ("blame",)
+
+
+def test_no_such_table_error_position_is_select_statement_position():
+    """`from_table` is a bare string on the AST with no position of its
+    own - the error points at `SelectStatement.position` (the `SELECT`
+    keyword) instead. `sqlite3`'s own CLI likewise prints no caret for
+    "no such table", confirmed directly, so there is no better position
+    to give a future renderer (#18)."""
+    stmt = parse(tokenize("SELECT path FROM ghost"))
+    with pytest.raises(BindError) as exc_info:
+        bind(stmt)
+    assert exc_info.value.position == stmt.position
+
+
+def test_unknown_from_table_error_preserves_exact_casing():
+    """`sqlite3`: `select path from GhOsT;` -> "no such table: GhOsT"
+    (verbatim, not folded)."""
+    with pytest.raises(BindError) as exc_info:
+        _bind("SELECT path FROM GhOsT")
+    assert str(exc_info.value) == "no such table: GhOsT"
+
+
+# --- Column resolution, bare and qualified, case-insensitive -----------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT PATH FROM blame",
+        "SELECT PaTh FROM blame",
+        "SELECT blame.PATH FROM blame",
+        "SELECT BlAmE.path FROM blame",
+        'SELECT "PATH" FROM blame',
+    ],
+)
+def test_column_resolves_case_insensitively(sql):
+    """All five spellings resolve to `blame.path`, offset 0."""
+    bound = _bind(sql)
+    assert len(bound.select_list) == 1
+    item = bound.select_list[0].expr
+    assert isinstance(item, BoundColumnRef)
+    assert item.offset == 0
+    assert item.name == "path"
+
+
+def test_ascii_only_folding_rejects_unicode_fold_of_straße():
+    """The one case a Unicode-aware fold gets wrong. `sqlite3` (table
+    `t(straße text)`): `select STRAßE from t` succeeds (`ß` is left
+    alone), `select STRASSE from t` fails with "no such column:
+    STRASSE" - Python's `'straße'.upper() == 'STRASSE'` would wrongly
+    match the second. `blame` has no non-ASCII column, so this uses a
+    synthetic single-column schema instead."""
+    schema = Schema(columns=(Column("straße", ColumnType.TEXT),))
+    catalog = {"t": schema}
+
+    ok = bind(parse(tokenize("SELECT STRAßE FROM t")), catalog)
+    assert isinstance(ok.select_list[0].expr, BoundColumnRef)
+    assert ok.select_list[0].expr.name == "straße"
+
+    with pytest.raises(BindError) as exc_info:
+        bind(parse(tokenize("SELECT STRASSE FROM t")), catalog)
+    assert str(exc_info.value) == "no such column: STRASSE"
+
+
+def test_bound_column_ref_carries_integer_offset():
+    """A resolved column reference carries a zero-based integer offset,
+    computed once via `Schema.index_of` - not a name `exec/
+    expression.py` would need to look up per row."""
+    bound = _bind("SELECT author_email FROM blame")
+    ref = bound.select_list[0].expr
+    assert isinstance(ref, BoundColumnRef)
+    assert ref.offset == BLAME_SCHEMA.index_of("author_email") == 5
+
+
+def _all_column_refs(expr: object) -> list[object]:
+    """Walk a bound expression tree and collect every leaf that
+    references a column, resolved or not - used to confirm no
+    unresolved `ColumnRef` survives binding anywhere in a deeply
+    nested tree, not only at the top level."""
+    if isinstance(expr, (BoundColumnRef, ColumnRef)):
+        return [expr]
+    found: list[object] = []
+    if dataclasses.is_dataclass(expr):
+        for field in dataclasses.fields(expr):
+            value = getattr(expr, field.name)
+            if isinstance(value, tuple):
+                for item in value:
+                    found.extend(_all_column_refs(item))
+            else:
+                found.extend(_all_column_refs(value))
+    return found
+
+
+def test_bound_tree_has_no_raw_column_ref_in_a_deeply_nested_where():
+    """`dataclasses.replace` threads bound children through every
+    composite node type, not only the ones exercised by simpler tests
+    above. Confirmed as valid, sensible SQL against sqlite3 (empty
+    result on an empty table, no error):
+
+        select 1 from blame where (line_no between 1 and 10)
+          and (path like 'src/%' or author_name in ('a','b'))
+          and not (commit_hash is null);
+
+    Every one of the five column references inside - in BETWEEN, LIKE,
+    IN, and IS NULL, nested under AND/OR/NOT - must come back as a
+    `BoundColumnRef` with the right offset, and no plain `ColumnRef`
+    may remain anywhere in the tree."""
+    bound = _bind(
+        "SELECT 1 FROM blame WHERE (line_no BETWEEN 1 AND 10) "
+        "AND (path LIKE 'src/%' OR author_name IN ('a', 'b')) "
+        "AND NOT (commit_hash IS NULL)"
+    )
+    refs = _all_column_refs(bound.where)
+    assert refs, "expected at least one column reference in the WHERE tree"
+    assert all(isinstance(ref, BoundColumnRef) for ref in refs), refs
+    by_name = {ref.name: ref.offset for ref in refs}
+    assert by_name == {
+        "line_no": BLAME_SCHEMA.index_of("line_no"),
+        "path": BLAME_SCHEMA.index_of("path"),
+        "author_name": BLAME_SCHEMA.index_of("author_name"),
+        "commit_hash": BLAME_SCHEMA.index_of("commit_hash"),
+    }
+
+
+# --- Output column naming -----------------------------------------------------
+
+
+def test_unaliased_column_output_name_is_declared_spelling():
+    """`sqlite3 -header`: `select PaTh from blame` headers `path`, not
+    `PaTh` - the declared schema spelling, not the user's typed
+    casing."""
+    bound = _bind("SELECT PaTh FROM blame")
+    assert bound.select_list[0].output_name == "path"
+
+
+def test_explicit_alias_used_verbatim():
+    """`sqlite3 -header`: `select path as PaTh from blame` headers
+    `PaTh` exactly as written - no folding of an explicit alias."""
+    bound = _bind("SELECT path AS PaTh FROM blame")
+    item = bound.select_list[0]
+    assert item.alias == "PaTh"
+    assert item.output_name == "PaTh"
+
+
+# --- SELECT * / table.* expansion ---------------------------------------------
+
+
+def test_star_expands_to_declared_column_order():
+    """`sqlite3` on a 7-column table shaped like `blame`: `select *`
+    returns columns in exactly the declared order."""
+    bound = _bind("SELECT * FROM blame")
+    assert [item.output_name for item in bound.select_list] == list(_BLAME_COLUMNS)
+    assert [item.expr.offset for item in bound.select_list] == list(range(7))
+
+
+@pytest.mark.parametrize("sql", ["SELECT blame.* FROM blame", "SELECT BlAmE.* FROM blame"])
+def test_qualified_star_expands_the_same_way(sql):
+    """`blame.*`, and a case-folded qualifier spelling of it, expand
+    the same as bare `*` - confirmed against sqlite3."""
+    bound = _bind(sql)
+    assert [item.output_name for item in bound.select_list] == list(_BLAME_COLUMNS)
+
+
+def test_qualified_star_wrong_table_raises_no_such_table_not_column():
+    """`sqlite3`: `select other.* from blame` (with a real, unrelated
+    `other` table) -> "no such table: other", never "no such column" -
+    the opposite of a qualified *column* with the same mistake, see
+    below."""
+    with pytest.raises(BindError) as exc_info:
+        bind(parse(tokenize("SELECT other.* FROM blame")), {"blame": BLAME_SCHEMA, "other": BLAME_SCHEMA})
+    err = exc_info.value
+    assert str(err) == "no such table: other"
+    assert set(err.available) == {"blame", "other"}
+
+
+def test_qualified_star_unknown_table_raises_no_such_table():
+    """`sqlite3`: `select ghost.* from blame` -> "no such table: ghost"."""
+    with pytest.raises(BindError) as exc_info:
+        _bind("SELECT ghost.* FROM blame")
+    assert str(exc_info.value) == "no such table: ghost"
+
+
+# --- Qualified column vs. qualified star: opposite error kinds ---------------
+
+
+def test_qualified_column_wrong_real_table_raises_no_such_column():
+    """`sqlite3`: `select other.path from blame` (real, unrelated
+    `other` table) -> "no such column: other.path", never "no such
+    table" - confirmed opposite of the qualified-star case above."""
+    with pytest.raises(BindError) as exc_info:
+        bind(parse(tokenize("SELECT other.path FROM blame")), {"blame": BLAME_SCHEMA, "other": BLAME_SCHEMA})
+    assert str(exc_info.value) == "no such column: other.path"
+
+
+def test_qualified_column_unknown_table_raises_no_such_column():
+    """`sqlite3`: `select ghost.path from blame` -> "no such column:
+    ghost.path", not "no such table: ghost"."""
+    with pytest.raises(BindError) as exc_info:
+        _bind("SELECT ghost.path FROM blame")
+    err = exc_info.value
+    assert str(err) == "no such column: ghost.path"
+    assert err.available == _BLAME_COLUMNS
+
+
+# --- Unknown bare column -------------------------------------------------------
+
+
+def test_unknown_bare_column_raises_no_such_column():
+    """`sqlite3`: `select authr_name from blame` -> "no such column:
+    authr_name"."""
+    with pytest.raises(BindError) as exc_info:
+        _bind("SELECT authr_name FROM blame")
+    err = exc_info.value
+    assert str(err) == "no such column: authr_name"
+    assert err.available == _BLAME_COLUMNS
+
+
+def test_no_such_column_error_preserves_exact_casing():
+    """`sqlite3`: `select AuThR_NaMe from blame` -> "no such column:
+    AuThR_NaMe" (verbatim, never folded or matched to the declared
+    `author_name`)."""
+    with pytest.raises(BindError) as exc_info:
+        _bind("SELECT AuThR_NaMe FROM blame")
+    assert str(exc_info.value) == "no such column: AuThR_NaMe"
+
+
+def test_no_such_column_error_carries_column_ref_position():
+    """The error's position is the offending `ColumnRef`'s own token
+    position, already on the AST from the parser - no new position
+    tracking needed here."""
+    stmt = parse(tokenize("SELECT authr_name FROM blame"))
+    ref = stmt.select_list[0].expr
+    with pytest.raises(BindError) as exc_info:
+        bind(stmt)
+    assert exc_info.value.position == ref.position
+
+
+def test_no_such_column_available_is_blame_columns_in_declared_order():
+    """Matches spec §5's worked example for this exact query: `blame
+    has: path, line_no, line, commit_hash, author_name, author_email,
+    authored_at`."""
+    with pytest.raises(BindError) as exc_info:
+        _bind("SELECT authr_name FROM blame")
+    assert exc_info.value.available == _BLAME_COLUMNS
+
+
+# --- Resolution order across clauses -------------------------------------------
+
+
+def test_from_table_resolved_before_select_list():
+    """`sqlite3`: `select authr_name from ghost;` reports the missing
+    table, not the missing column - `FROM` is checked first regardless
+    of `SelectStatement`'s own field order (select_list, from_table,
+    where)."""
+    with pytest.raises(BindError) as exc_info:
+        _bind("SELECT authr_name FROM ghost")
+    assert str(exc_info.value) == "no such table: ghost"
+
+
+def test_leftmost_select_item_reported_first():
+    """`sqlite3`: `select ghost1, ghost2 from blame;` reports `ghost1`."""
+    with pytest.raises(BindError) as exc_info:
+        _bind("SELECT ghost1, ghost2 FROM blame")
+    assert str(exc_info.value) == "no such column: ghost1"
+
+
+def test_select_list_resolved_before_where():
+    """`sqlite3`: `select ghost_select from blame where ghost_where =
+    1;` reports `ghost_select`, not `ghost_where`."""
+    with pytest.raises(BindError) as exc_info:
+        _bind("SELECT ghost_select FROM blame WHERE ghost_where = 1")
+    assert str(exc_info.value) == "no such column: ghost_select"
+
+
+# --- Aliases: no cross-item namespace, no WHERE fallback (deferred) ----------
+
+
+def test_alias_not_visible_to_next_select_item():
+    """`sqlite3`: `select path as p, p as p2 from blame;` errors "no
+    such column: p" on the second item - SQLite evaluates every
+    select-list expression against FROM alone, none see each other's
+    aliases."""
+    with pytest.raises(BindError) as exc_info:
+        _bind("SELECT path AS p, p AS p2 FROM blame")
+    assert str(exc_info.value) == "no such column: p"
+
+
+def test_where_referencing_select_list_alias_conservatively_rejected():
+    """Real SQLite behaviour (`select path as p, line_no from blame
+    where p = 'a.py'` succeeds) that this issue deliberately does not
+    implement - see #32. Until that lands, `WHERE p` raises "no such
+    column: p", the safe direction: a query SQLite accepts is wrongly
+    rejected, never a silently wrong row. Pinned here so the gap is
+    deliberate rather than an untested accident."""
+    with pytest.raises(BindError) as exc_info:
+        _bind("SELECT path AS p FROM blame WHERE p = 'x'")
+    assert str(exc_info.value) == "no such column: p"
+
+
+# --- Star in the wrong position: defensive backstop ---------------------------
+#
+# Constructed directly as an AST, bypassing the parser - #31 tracks
+# the parser bug that lets some of these through today
+# (`SELECT * AS x`, `count(blame.*)`); the third (`*` inside a general
+# expression) already fails to parse. This issue's job is only to make
+# sure the binder itself never crashes or silently mis-expands if a
+# malformed tree reaches it, by whatever means.
+
+
+def test_star_with_alias_raises_defensive_error():
+    """`select * as x from blame` -> `near "as": syntax error` in
+    sqlite3; historian's parser currently accepts it (#31). The binder
+    rejects a `Star` select-item that carries an alias rather than
+    silently aliasing the whole expansion."""
+    stmt = SelectStatement(
+        select_list=(SelectItem(expr=Star(table=None, position=_POS), alias="x", position=_POS),),
+        from_table="blame",
+        where=None,
+        position=_POS,
+    )
+    with pytest.raises(BindError):
+        bind(stmt)
+
+
+def test_star_in_general_expression_position_raises_defensive_error():
+    """`select path from blame where blame.* = 1` -> `near "*": syntax
+    error` in sqlite3; already rejected by historian's own parser
+    today, but the binder is tested directly against a hand-built tree
+    so this stays true independent of parser behaviour."""
+    where = Star(table="blame", position=_POS)
+    stmt = SelectStatement(
+        select_list=(SelectItem(expr=Literal(1, _POS), alias=None, position=_POS),),
+        from_table="blame",
+        where=where,
+        position=_POS,
+    )
+    with pytest.raises(BindError):
+        bind(stmt)
+
+
+def test_qualified_star_as_function_argument_raises_defensive_error():
+    """`select count(blame.*) from blame` -> `near "*": syntax error`
+    in sqlite3; historian's parser currently accepts it (#31). A
+    *qualified* star as a function's sole argument is not the same
+    case as `count(*)` (unqualified, passed through unexpanded below)
+    and is rejected here."""
+    call = FunctionCall(name="count", args=(Star(table="blame", position=_POS),), position=_POS)
+    stmt = SelectStatement(
+        select_list=(SelectItem(expr=call, alias=None, position=_POS),),
+        from_table="blame",
+        where=None,
+        position=_POS,
+    )
+    with pytest.raises(BindError):
+        bind(stmt)
+
+
+def test_star_as_non_sole_function_argument_raises_defensive_error():
+    """`count(*, path)` -> `near ",": syntax error` in sqlite3, already
+    rejected by historian's parser too. Checked directly against a
+    hand-built tree: a `Star` alongside another argument is not "the
+    sole argument" and is rejected rather than silently expanded or
+    passed through."""
+    call = FunctionCall(
+        name="count",
+        args=(Star(table=None, position=_POS), ColumnRef(table=None, name="path", position=_POS)),
+        position=_POS,
+    )
+    stmt = SelectStatement(
+        select_list=(SelectItem(expr=call, alias=None, position=_POS),),
+        from_table="blame",
+        where=None,
+        position=_POS,
+    )
+    with pytest.raises(BindError):
+        bind(stmt)
+
+
+def test_count_star_passed_through_unexpanded():
+    """`count(*)` is the one place `Star` legitimately survives into
+    the bound tree, unexpanded and unvalidated - `*` there means "no
+    columns", not "all columns", and this issue does not check whether
+    `count` is a real function."""
+    bound = _bind("SELECT count(*) FROM blame")
+    call = bound.select_list[0].expr
+    assert isinstance(call, FunctionCall)
+    assert len(call.args) == 1
+    assert isinstance(call.args[0], Star)
+    assert call.args[0].table is None
+
+
+# --- Explicitly out of scope, pinned so the gap is deliberate ----------------
+
+
+def test_type_affinity_is_not_checked_at_bind_time():
+    """`WHERE line_no = '5'` binds successfully: `line_no` is a real
+    `INTEGER` column, and whether `'5'` needs coercing to compare
+    against it is `exec/expression.py`'s job (#12), not this module's."""
+    bound = _bind("SELECT path FROM blame WHERE line_no = '5'")
+    assert bound.where is not None
+
+
+def test_function_name_and_arity_are_not_validated():
+    """`SELECT nonexistent_fn(path) FROM blame` binds successfully -
+    the `path` reference inside resolves normally, and whether
+    `nonexistent_fn` is real is left to a future function registry."""
+    bound = _bind("SELECT nonexistent_fn(path) FROM blame")
+    call = bound.select_list[0].expr
+    assert isinstance(call, FunctionCall)
+    assert call.name == "nonexistent_fn"
+    arg = call.args[0]
+    assert isinstance(arg, BoundColumnRef)
+    assert arg.name == "path"
+
+
+# --- No git, no subprocess needed to exercise this module --------------------
+
+
+def test_binder_module_does_not_import_subprocess_directly():
+    """`bind()` and everything it calls are tested entirely against
+    in-memory `Schema`/`SelectStatement` values above, with no
+    repository present - per `AGENTS.md`'s "only scan operators touch
+    git". This module does not itself write `import subprocess` (it
+    only transitively imports a module that does, via `BLAME_SCHEMA` -
+    see the module docstring's own note on that trade-off), so
+    `subprocess` never appears as a name bound directly in its own
+    namespace."""
+    import historian.sql.binder as binder_module
+
+    assert "subprocess" not in vars(binder_module)


### PR DESCRIPTION
Closes #9.

The binder sits between the parser and the planner: it resolves an AST's names against the schema of the tables in its `FROM` clause, and errors on names that do not resolve.

## What this adds

**`src/historian/sql/binder.py`** — the table catalog (`TABLES`, mapping name to `Schema`), `bind(stmt, catalog) -> BoundSelectStatement`, the bound-tree node types, and `BindError`.

The catalog imports `BLAME_SCHEMA` from `tables/blame.py` rather than restating §2's seven columns — QA confirmed `TABLES["blame"] is BLAME_SCHEMA` by identity, not equality, so there is no second copy to drift.

Per §3, column references resolve to **integer offsets at bind time** rather than by name at runtime, so rows stay cheap. The parser stays schema-blind and unchanged.

## Case folding is ASCII-only, and the obvious implementation is wrong

SQLite folds `A`-`Z` and nothing else. Python's `str.lower()` and `str.casefold()` are Unicode-aware and fold more, so a binder built on them accepts identifiers SQLite rejects — a differential mismatch, and `AGENTS.md` makes SQLite right by definition.

Two cases where they diverge, both verified:

```
column declared "straße"
  select STRAßE   -> resolves in both        (ß unchanged by ASCII folding)
  select STRASSE  -> no such column          but 'straße'.upper() == 'STRASSE'

column declared "k"
  select K        -> no such column          K is U+212A, the Kelvin sign
                                             but 'K'.lower() == ascii 'k'
```

Confirmed against `sqlite3` 3.51.0 rather than reasoned about:

```
$ sqlite3 :memory: 'create table t(k text); select K from t;'
Error: in prepare, no such column: K
```

The implementation is an explicit `A`-`Z` → `a`-`z` map, checked by codepoint:

```
input   codepoints   _ascii_fold   .lower()
'K'     U+212A       U+212A        U+006B     <- Kelvin, correctly left alone
'K'     U+004B       U+006B        U+006B     <- ASCII, correctly folded
'ı'     U+0131       U+0131        U+0131     <- Turkish dotless, left alone
```

This is the kind of defect that survives every hand-written test and surfaces only when someone fuzzes non-ASCII identifiers, which is why it was worth chasing past the one case the criteria pinned.

## Three behaviours that look wrong and are correct

**Resolution order is FROM, then select list left-to-right, then WHERE — first failure wins.** That is the opposite of the AST's own field order, so it does not fall out of a naive traversal; it is checked explicitly in `bind()`. A query with both a bad table and a bad column reports the table, matching SQLite.

**Wrong-table references produce different error kinds for what looks like the same mistake:**

```
select other.path from blame   ->  no such column: other.path
select other.*    from blame   ->  no such table: other
```

Verified against SQLite. Matching it means matching the error *class*, which is the standard #16 set for the lexer.

**Output column names use the declared schema spelling**, not the user's typing. `SELECT PaTh FROM blame` headers as `path`, confirmed with `sqlite3 -header`. An explicit alias is used verbatim.

## What the binder deliberately does not do

§3 warns against inventing runtime type errors: SQLite is permissive, and every error historian raises that SQLite does not is a differential mismatch. So `WHERE path = 5`, `WHERE line_no = 'abc'` and `SELECT path + 1` all bind cleanly here, exactly as they run cleanly in SQLite. Affinity belongs to `exec/expression.py` in #12.

The rendered §5 error format — the caret, the wrapped `blame has:` list — is milestone item 18. The binder raises *structured* errors carrying message, position and available names; rendering them is a separate concern with its own issue.

## Verification

**QA verdict: PASS** — https://github.com/ionut-banu/historian/issues/9#issuecomment-5496000697

All **26 acceptance criteria** ticked with per-criterion evidence, checked against live `sqlite3` rather than against the issue's prose. `uv run pytest` gives **506 passed**, against 464 on `main`. 42 new tests, zero removed lines.

`Differential: n/a, no suite until M3` · `Fuzzer: n/a, not built until M5`

**QA broke the implementation three separate times and watched the right tests go red**, then restored:

- `_same_name` changed to `a.upper() == b.upper()` — the exact wrong implementation — turned the `straße` test red.
- The resolution order in `bind()` reversed — turned the select-list-before-WHERE test red.
- `_bind_star`'s error kind changed — turned both asymmetry tests red.

It also stress-tested the folding past the pinned case, on the Kelvin sign and Turkish dotless `ı`, and checked the integer offsets **positionally** against `BLAME_SCHEMA.index_of` including inside a deeply nested `WHERE` tree — an offset that is present but wrong produces confidently wrong values rather than an error, and only a positional check finds it.

## Follow-ups filed, not fixed here

- **#31** — the parser accepts `SELECT * AS x` and `count(blame.*)`, which SQLite rejects as syntax errors. A parser fix, not something the binder should paper over.
- **#32** — `WHERE` cannot reference a select-list alias, which SQLite allows as a fallback. Deferred because it needs expression substitution rather than offset resolution. The interim behaviour is a conservative false rejection — historian errors where SQLite answers — which is the safe direction and is pinned by a criterion.
